### PR TITLE
Ensure WooCommerce price filter uses explicit range

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -795,9 +795,10 @@ class GPT5_Shop_Assistant_Onefile {
             's' => $q,
         ];
         if ($min_price || $max_price) {
+            $range = [max(0, $min_price), $max_price > 0 ? $max_price : PHP_INT_MAX];
             $args['meta_query'] = [[
                 'key' => '_price',
-                'value' => array_filter([$min_price ?: 0, $max_price ?: PHP_INT_MAX]),
+                'value' => $range,
                 'compare' => 'BETWEEN',
                 'type' => 'NUMERIC',
             ]];


### PR DESCRIPTION
## Summary
- ensure the WooCommerce search meta query always sends a two-value range to the BETWEEN comparator
- fall back to PHP_INT_MAX when no explicit upper bound is provided so the price filter remains inclusive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80adf20188324bfa495de3db4643d