### PR TITLE
Normalize origin validation in security header check

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -544,9 +544,14 @@ class GPT5_Shop_Assistant_Onefile {
             return new WP_Error('forbidden', __('Nonce inválido', 'gpt5-sa'), ['status' => 403]);
         }
         $allowed = array_map('trim', explode(',', $opts['allowed_origins']));
+        $allowed = array_filter($allowed, function($x) { return $x !== ''; });
+        $allowed = array_map(function($x){ return $this->normalize_origin_str($x); }, $allowed);
         $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-        if ($origin && !in_array($origin, $allowed, true)) {
-            return new WP_Error('forbidden', __('Origen no permitido', 'gpt5-sa'), ['status' => 403]);
+        if ($origin) {
+            $norm_origin = $this->normalize_origin_str($origin);
+            if (!in_array($norm_origin, $allowed, true)) {
+                return new WP_Error('forbidden', __('Origen no permitido', 'gpt5-sa'), ['status' => 403]);
+            }
         }
         $this->cors_header();
         return true;


### PR DESCRIPTION
## Summary
- normalize stored allowed origins in `check_security_headers()` using the existing helper
- ensure incoming request origins are normalized before validation while keeping the CORS header emission

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80adc665c8324ba0f481bc5aedf10