### PR TITLE
Normalize origin comparison in security header checks

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -545,8 +545,12 @@ class GPT5_Shop_Assistant_Onefile {
         }
         $allowed = array_map('trim', explode(',', $opts['allowed_origins']));
         $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-        if ($origin && !in_array($origin, $allowed, true)) {
-            return new WP_Error('forbidden', __('Origen no permitido', 'gpt5-sa'), ['status' => 403]);
+        if ($origin) {
+            $normalized_origin = $this->normalize_origin_str($origin);
+            $allowed = array_map(function($x){ return $this->normalize_origin_str($x); }, $allowed);
+            if (!in_array($normalized_origin, $allowed, true)) {
+                return new WP_Error('forbidden', __('Origen no permitido', 'gpt5-sa'), ['status' => 403]);
+            }
         }
         $this->cors_header();
         return true;


### PR DESCRIPTION
## Summary
- normalize the request origin and the configured allowlist inside `check_security_headers` before validating access
- preserve the original Origin header for response headers while ensuring normalized comparisons avoid trailing slash mismatches

## Testing
- php -r '$normalize=function($o){$o=trim(strtolower($o));$o=rtrim($o,"/");return $o;};$allowed=array_map("trim",explode(",","https://tu-sitio.com/"));$allowed=array_map($normalize,$allowed);$origin="https://tu-sitio.com";var_dump(in_array($normalize($origin),$allowed,true));'


------
https://chatgpt.com/codex/tasks/task_e_68d808ce0c4c8324a07bbd973fb328a0