### PR TITLE
Add cURL availability guard for streaming proxy

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -695,6 +695,20 @@ class GPT5_Shop_Assistant_Onefile {
             $headers = ['Authorization: Bearer '.$opts['api_key'], 'Content-Type: application/json'];
         }
 
+        if (!function_exists('curl_init') || !function_exists('curl_exec')) {
+            $payload['stream'] = false;
+            $resp = $this->call_provider($payload, $opts, $provider);
+            if (is_wp_error($resp)) {
+                return $resp;
+            }
+            $text = $resp['text'] ?? '';
+            if ($text !== '') {
+                echo 'data: ' . wp_json_encode(['delta' => $text]) . "\n\n";
+                @ob_flush(); @flush();
+            }
+            return null;
+        }
+
         $payload['stream'] = true;
         $ch = curl_init($url);
         curl_setopt_array($ch, [


### PR DESCRIPTION
## Summary
- add a cURL availability check in the streaming proxy and fall back to the non-streaming provider call when unavailable
- ensure SSE responses still emit data while avoiding fatal errors when cURL is missing

## Testing
- php -l gpt5-shop-assistant-onefile.php

------
https://chatgpt.com/codex/tasks/task_e_68d8068a34048324b3adc9b6300f92c2