### PR TITLE
Handle WooCommerce search price bounds explicitly

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -794,11 +794,25 @@ class GPT5_Shop_Assistant_Onefile {
             'return' => 'ids',
             's' => $q,
         ];
-        if ($min_price || $max_price) {
+        if ($min_price && $max_price) {
             $args['meta_query'] = [[
                 'key' => '_price',
-                'value' => array_filter([$min_price ?: 0, $max_price ?: PHP_INT_MAX]),
+                'value' => [$min_price, $max_price],
                 'compare' => 'BETWEEN',
+                'type' => 'NUMERIC',
+            ]];
+        } elseif ($min_price) {
+            $args['meta_query'] = [[
+                'key' => '_price',
+                'value' => $min_price,
+                'compare' => '>=',
+                'type' => 'NUMERIC',
+            ]];
+        } elseif ($max_price) {
+            $args['meta_query'] = [[
+                'key' => '_price',
+                'value' => $max_price,
+                'compare' => '<=',
                 'type' => 'NUMERIC',
             ]];
         }


### PR DESCRIPTION
## Summary
- adjust the WooCommerce search price meta query to handle minimum, maximum, and combined bounds explicitly

## Testing
- curl -sS "http://localhost/wp-json/gpt5sa/v1/wc-search?max_price=50" *(fails: Could not connect to server in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d806898be4832484c4f2db74e83a9f