### PR TITLE
Enhance GPT-5 assistant styling and knowledge context

### DIFF
--- a/gpt5-shop-assistant-onefile.php
+++ b/gpt5-shop-assistant-onefile.php
@@ -92,7 +92,7 @@ class GPT5_Shop_Assistant_Onefile {
             'azure_api_version' => '2024-06-01',
             'openrouter_site' => '',
             'openrouter_title' => 'GPT5 Shop Assistant',
-            'model' => 'gpt-4o-mini',
+            'model' => 'gpt-5.1-mini',
             'max_tokens' => 512,
             'temperature' => 0.7,
             'allowed_origins' => home_url(),
@@ -315,38 +315,58 @@ class GPT5_Shop_Assistant_Onefile {
 
     private function widget_css() {
         return "
-#gpt5sa-launcher{position:fixed;right:20px;bottom:20px;z-index:99999}
-#gpt5sa-launcher button{border:none;border-radius:16px;padding:12px 16px;box-shadow:0 6px 20px rgba(0,0,0,.15);cursor:pointer;background:#111827;color:#fff}
-#gpt5sa-panel{position:fixed;right:20px;bottom:80px;width:410px;max-width:95vw;height:580px;display:none;background:#fff;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.2);overflow:hidden;z-index:99999}
-#gpt5sa-header{display:flex;align-items:center;justify-content:space-between;background:#111827;color:#fff;padding:10px 14px}
-#gpt5sa-tabs{display:flex;gap:6px;padding:8px;border-bottom:1px solid #eee}
-#gpt5sa-tabs button{border:none;background:#f3f4f6;padding:6px 10px;border-radius:999px;cursor:pointer}
-#gpt5sa-tabs button.active{background:#111827;color:#fff}
-#gpt5sa-messages{height:calc(100% - 240px);overflow:auto;padding:12px}
-#gpt5sa-input{display:flex;gap:8px;padding:10px;border-top:1px solid #eee}
-#gpt5sa-input textarea{flex:1;resize:none;height:42px;padding:8px;border-radius:10px;border:1px solid #ddd}
-#gpt5sa-input button{border:none;border-radius:10px;padding:8px 12px;cursor:pointer;background:#111827;color:#fff}
-.gpt5sa-msg{margin:8px 0}
+#gpt5sa-launcher{position:fixed;right:20px;bottom:20px;z-index:99999;font-family:'Inter',sans-serif}
+#gpt5sa-launcher button{border:none;border-radius:999px;padding:14px 20px;box-shadow:0 24px 45px rgba(17,24,39,.18);cursor:pointer;background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff;font-weight:600;font-size:15px;display:flex;align-items:center;gap:10px;transition:transform .2s ease,box-shadow .2s ease}
+#gpt5sa-launcher button:hover{transform:translateY(-2px);box-shadow:0 30px 60px rgba(17,24,39,.25)}
+#gpt5sa-launcher button .pulse{display:inline-block;width:8px;height:8px;border-radius:50%;background:#34d399;box-shadow:0 0 0 6px rgba(52,211,153,.35);animation:gpt5sapulse 1.8s infinite}
+@keyframes gpt5sapulse{0%{transform:scale(.9)}50%{transform:scale(1.3);opacity:.7}100%{transform:scale(.9);opacity:1}}
+#gpt5sa-panel{position:fixed;right:20px;bottom:90px;width:430px;max-width:95vw;height:620px;display:none;background:#fff;border-radius:20px;box-shadow:0 30px 60px rgba(15,23,42,.28);overflow:hidden;z-index:99999;font-family:'Inter',sans-serif}
+#gpt5sa-header{display:flex;align-items:center;justify-content:space-between;background:linear-gradient(135deg,#111827,#1f2937);color:#fff;padding:14px 18px}
+#gpt5sa-header strong{font-size:16px}
+#gpt5sa-header button{background:transparent;border:none;color:#fff;font-size:18px;cursor:pointer}
+#gpt5sa-tabs{display:flex;gap:8px;padding:12px 16px;border-bottom:1px solid rgba(148,163,184,.2);background:#f9fafb}
+#gpt5sa-tabs button{border:none;background:#e2e8f0;padding:7px 14px;border-radius:999px;cursor:pointer;font-size:13px;font-weight:600;color:#334155;transition:all .2s ease}
+#gpt5sa-tabs button.active{background:#111827;color:#fff;box-shadow:0 8px 20px rgba(15,23,42,.18)}
+#gpt5sa-messages{height:calc(100% - 270px);overflow:auto;padding:16px;background:#fff}
+#gpt5sa-input{display:flex;gap:10px;padding:14px 16px;border-top:1px solid rgba(148,163,184,.2);background:#f8fafc}
+#gpt5sa-input textarea{flex:1;resize:none;height:52px;padding:12px;border-radius:14px;border:1px solid rgba(148,163,184,.5);font-family:inherit;font-size:14px;box-shadow:inset 0 1px 2px rgba(15,23,42,.08)}
+#gpt5sa-input textarea:focus{outline:none;border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.2)}
+#gpt5sa-input button{border:none;border-radius:14px;padding:12px 18px;cursor:pointer;background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff;font-weight:600;font-size:14px;display:flex;align-items:center;gap:6px;transition:transform .2s ease,box-shadow .2s ease}
+#gpt5sa-input button:hover{transform:translateY(-1px);box-shadow:0 18px 28px rgba(99,102,241,.3)}
+.gpt5sa-msg{margin:10px 0;font-size:14px;line-height:1.5;color:#1f2937}
 .gpt5sa-msg.user{text-align:right}
-.gpt5sa-badge{display:inline-block;background:#e5e7eb;color:#111827;padding:2px 8px;border-radius:999px;margin-right:6px}
-#gpt5sa-filters{display:none;padding:10px;border-bottom:1px solid #eee;gap:8px;align-items:center;flex-wrap:wrap}
-#gpt5sa-filters input,#gpt5sa-filters select{border:1px solid #ddd;border-radius:8px;padding:6px 8px}
-#gpt5sa-chips{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px}
-#gpt5sa-chips .chip{background:#f3f4f6;border:1px solid #e5e7eb;border-radius:999px;padding:4px 10px;cursor:pointer;font-size:12px}
-#gpt5sa-grid{display:none;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;padding:10px;overflow:auto;height:calc(100% - 210px)}
-.gpt5sa-card{border:1px solid #eee;border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
-.gpt5sa-card img{width:100%;height:140px;object-fit:cover;background:#f9fafb}
-.gpt5sa-card .body{padding:8px;display:flex;flex-direction:column;gap:6px;flex:1}
-.gpt5sa-card .body .name{font-weight:600;font-size:14px;line-height:1.2;margin:0}
-.gpt5sa-card .body .price{font-size:13px}
+.gpt5sa-msg.user em{background:rgba(99,102,241,.08);padding:8px 12px;border-radius:16px 16px 4px 16px;display:inline-block}
+.gpt5sa-msg.bot{display:flex;align-items:flex-start;gap:10px}
+.gpt5sa-msg.bot:before{content:'🤖';display:inline-flex;width:32px;height:32px;border-radius:50%;background:#e0e7ff;align-items:center;justify-content:center;font-size:17px}
+.gpt5sa-msg.bot .gpt5sa-stream{display:inline-block;white-space:pre-wrap;background:#f1f5f9;padding:8px 12px;border-radius:16px 16px 16px 4px}
+.gpt5sa-badge{display:inline-flex;background:rgba(255,255,255,.2);color:#fff;padding:4px 10px;border-radius:999px;margin-right:6px;font-size:11px;text-transform:uppercase;letter-spacing:.08em}
+#gpt5sa-filters{display:none;padding:14px 16px;border-bottom:1px solid rgba(148,163,184,.2);gap:10px;align-items:center;flex-wrap:wrap;background:#f9fafb}
+#gpt5sa-filters input,#gpt5sa-filters select{border:1px solid rgba(148,163,184,.4);border-radius:12px;padding:8px 12px;font-size:13px;background:#fff;min-width:100px}
+#gpt5sa-filters label{font-size:12px;color:#475569}
+#gpt5sa-chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:6px}
+#gpt5sa-chips .chip{background:#e0e7ff;color:#312e81;border-radius:999px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:600;transition:transform .2s ease,box-shadow .2s ease}
+#gpt5sa-chips .chip:hover{transform:translateY(-1px);box-shadow:0 10px 18px rgba(99,102,241,.2)}
+#gpt5sa-grid{display:none;padding:12px 16px;overflow:hidden;height:calc(100% - 230px);background:#fff}
+.gpt5sa-carousel{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;padding-bottom:6px}
+.gpt5sa-carousel::-webkit-scrollbar{height:6px}
+.gpt5sa-carousel::-webkit-scrollbar-thumb{background:#cbd5f5;border-radius:999px}
+.gpt5sa-carousel .gpt5sa-card{min-width:190px;max-width:190px;scroll-snap-align:start;background:#fff;border-radius:16px;box-shadow:0 16px 30px rgba(15,23,42,.12);border:1px solid rgba(148,163,184,.25);overflow:hidden;display:flex;flex-direction:column;transition:transform .2s ease,box-shadow .2s ease}
+.gpt5sa-carousel .gpt5sa-card:hover{transform:translateY(-4px);box-shadow:0 26px 42px rgba(15,23,42,.18)}
+.gpt5sa-card img{width:100%;height:140px;object-fit:cover;background:#f8fafc}
+.gpt5sa-card .body{padding:12px;display:flex;flex-direction:column;gap:8px;flex:1}
+.gpt5sa-card .body .name{font-weight:600;font-size:15px;line-height:1.3;margin:0;color:#111827}
+.gpt5sa-card .body .price{font-size:14px;color:#4338ca;font-weight:600}
 .gpt5sa-card .row{display:flex;align-items:center;justify-content:space-between;gap:8px}
-.gpt5sa-card .btn{display:inline-block;background:#111827;color:#fff;padding:6px 10px;border-radius:8px;text-decoration:none;border:none;cursor:pointer}
+.gpt5sa-card .btn{display:inline-flex;align-items:center;justify-content:center;background:#111827;color:#fff;padding:7px 12px;border-radius:10px;text-decoration:none;border:none;cursor:pointer;font-size:12px;font-weight:600;transition:background .2s ease}
+.gpt5sa-card .btn:hover{background:#312e81}
 .gpt5sa-card .muted{color:#6b7280;font-size:12px}
-.gpt5sa-empty{padding:20px;text-align:center;color:#6b7280}
-.gpt5sa-toast{position:fixed;right:20px;bottom:90px;background:#111827;color:#fff;padding:10px 12px;border-radius:10px;box-shadow:0 6px 20px rgba(0,0,0,.2);display:none;z-index:100000}
-#gpt5sa-recs{display:none;padding:10px;overflow:auto;height:calc(100% - 210px)}
-#gpt5sa-recs .title{font-weight:600;margin:2px 0 8px}
-#gpt5sa-recs .list{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.gpt5sa-card select.var{width:100%;border-radius:10px;border:1px solid rgba(148,163,184,.4);padding:7px 10px;font-size:12px}
+.gpt5sa-empty{padding:24px;text-align:center;color:#64748b;font-size:14px;border-radius:16px;background:#f8fafc}
+.gpt5sa-toast{position:fixed;right:24px;bottom:110px;background:#111827;color:#fff;padding:12px 16px;border-radius:14px;box-shadow:0 16px 30px rgba(15,23,42,.28);display:none;z-index:100000;font-size:13px;font-weight:600}
+#gpt5sa-recs{display:none;padding:12px 16px;overflow:hidden;height:calc(100% - 230px);background:#fff}
+#gpt5sa-recs .title{font-weight:600;margin:6px 0 12px;font-size:15px;color:#1f2937}
+#gpt5sa-recs .list{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;padding-bottom:6px}
+#gpt5sa-recs .list .gpt5sa-card{min-width:190px}
 ";
     }
 
@@ -446,11 +466,11 @@ class GPT5_Shop_Assistant_Onefile {
 (function(){
   if(document.getElementById('gpt5sa-launcher')) return;
   const launch = document.createElement('div'); launch.id='gpt5sa-launcher';
-  launch.innerHTML = '<button aria-controls=\"gpt5sa-panel\" aria-expanded=\"false\" aria-label=\"Open assistant\" class=\"gpt5sa-open\">🤖 '+(window.gpt5sa_title||'Asistente')+'</button>';
+  launch.innerHTML = '<button aria-controls=\"gpt5sa-panel\" aria-expanded=\"false\" aria-label=\"Abrir asistente GPT-5\" class=\"gpt5sa-open\"><span class=\"pulse\" aria-hidden=\"true\"></span><span class=\"label\">🤖 '+(window.gpt5sa_title||'Asistente GPT-5')+'</span></button>';
   document.body.appendChild(launch);
 
   const panel = document.createElement('div'); panel.id='gpt5sa-panel'; panel.setAttribute('role','dialog'); panel.setAttribute('aria-modal','true'); panel.setAttribute('aria-labelledby','gpt5sa-title');
-  panel.innerHTML = '<div id=\"gpt5sa-header\"><div><span class=\"gpt5sa-badge\" aria-live=\"polite\">beta</span><strong id=\"gpt5sa-title\">GPT-5 Assistant</strong></div><div style=\"display:flex;gap:8px;align-items:center\"><button id=\"gpt5sa-cart\" class=\"gpt5sa-open-cart\" aria-label=\"Ver carrito\">🛒</button><button class=\"gpt5sa-close\" aria-label=\"Close\">✖</button></div></div>' +
+  panel.innerHTML = '<div id=\"gpt5sa-header\"><div><span class=\"gpt5sa-badge\" aria-live=\"polite\">AI SHOP</span><strong id=\"gpt5sa-title\">GPT-5 Assistant</strong></div><div style=\"display:flex;gap:8px;align-items:center\"><button id=\"gpt5sa-cart\" class=\"gpt5sa-open-cart\" aria-label=\"Ver carrito\">🛒</button><button class=\"gpt5sa-close\" aria-label=\"Cerrar asistente\">✕</button></div></div>' +
     '<div id=\"gpt5sa-tabs\"><button data-tab=\"chat\" class=\"active\">Chat</button><button data-tab=\"catalog\" '+($enable_catalog?'':'style=\"display:none\"')+'>Catálogo</button><button data-tab=\"recs\" '+($enable_recs?'':'style=\"display:none\"')+'>Recomendados</button></div>' +
     '<div id=\"gpt5sa-filters\"><div style=\"display:flex;gap:6px;align-items:center;flex-wrap:wrap\">' +
       '<input placeholder=\"Buscar…\" id=\"gpt5sa-q\"/> ' +
@@ -494,7 +514,7 @@ class GPT5_Shop_Assistant_Onefile {
     const isCat = tab==='catalog';
     const isRecs = tab==='recs';
     filters.style.display = isCat ? 'block':'none';
-    grid.style.display = isCat ? 'grid':'none';
+    grid.style.display = isCat ? 'block':'none';
     messages.style.display = (!isCat && !isRecs) ? 'block':'none';
     recs.style.display = isRecs ? 'block':'none';
     if(isCat){ buildDynamicChips(); runSearch(); }
@@ -592,7 +612,7 @@ class GPT5_Shop_Assistant_Onefile {
 
   function renderGrid(items){
     if(!items.length){ grid.innerHTML = '<div class=\"gpt5sa-empty\">Sin resultados</div>'; return; }
-    grid.innerHTML = items.map(item=>{
+    const cards = items.map(item=>{
       const add = item.stock ? '<button class=\"btn add\" data-id=\"'+item.id+'\">Agregar</button>' : '<span class=\"muted\">Agotado</span>';
       const varSel = (item.variations && item.variations.length) ?
         ('<select class=\"var\" data-id=\"'+item.id+'\">'+ item.variations.map(v=>'<option value=\"'+v.variation_id+'\">'+v.attributes.join(' / ')+'</option>').join('') +'</select>')
@@ -605,6 +625,7 @@ class GPT5_Shop_Assistant_Onefile {
         '<div class=\"row\"><a class=\"btn\" href=\"'+item.permalink+'\">Ver</a>'+add+'</div>'+
         '<div class=\"muted\">'+(item.brand||'')+'</div></div></div>';
     }).join('');
+    grid.innerHTML = '<div class=\"gpt5sa-carousel\">'+cards+'</div>';
     grid.querySelectorAll('.btn.add').forEach(b=>b.addEventListener('click', ()=>addToCart(b)));
   }
 
@@ -629,7 +650,7 @@ class GPT5_Shop_Assistant_Onefile {
       const data = await resp.json();
       const items = data.items||[];
       if(!items.length){ recsList.innerHTML = '<div class=\"gpt5sa-empty\">Sin recomendaciones</div>'; return; }
-      recsList.innerHTML = items.map(item=>{
+      const cards = items.map(item=>{
         const add = item.stock ? '<button class=\"btn add\" data-id=\"'+item.id+'\">Agregar</button>' : '<span class=\"muted\">Agotado</span>';
         return '<div class=\"gpt5sa-card\">'+
           '<img src=\"'+(item.image||'')+'\" alt=\"\"/>'+
@@ -638,6 +659,7 @@ class GPT5_Shop_Assistant_Onefile {
           '<div class=\"row\"><a class=\"btn\" href=\"'+item.permalink+'\">Ver</a>'+add+'</div>'+
           '<div class=\"muted\">'+(item.brand||'')+'</div></div></div>';
       }).join('');
+      recsList.innerHTML = '<div class=\"gpt5sa-carousel\">'+cards+'</div>';
       recsList.querySelectorAll('.btn.add').forEach(b=>b.addEventListener('click', ()=>addToCart(b)));
     }catch(e){
       recsList.innerHTML = '<div class=\"gpt5sa-empty\">Error</div>';
@@ -734,6 +756,213 @@ class GPT5_Shop_Assistant_Onefile {
         return $text;
     }
 
+    private function build_rag_context($message) {
+        $context = [];
+        $keywords = $this->extract_keywords($message);
+
+        if (class_exists('WooCommerce')) {
+            $context = array_merge($context, $this->context_from_products($message, $keywords));
+        }
+
+        $context = array_merge($context, $this->context_from_content($message));
+        $context = array_merge($context, $this->build_sitemap_context($keywords));
+
+        $context = array_values(array_filter(array_unique($context)));
+        return array_slice($context, 0, 6);
+    }
+
+    private function extract_keywords($message) {
+        $message = strtolower((string) $message);
+        $parts = preg_split('/[^a-z0-9áéíóúñü]+/u', $message);
+        $parts = array_filter(array_map('trim', (array) $parts), function($w) {
+            return mb_strlen($w) >= 3;
+        });
+        $parts = array_values(array_unique($parts));
+        return array_slice($parts, 0, 10);
+    }
+
+    private function context_from_products($message, $keywords) {
+        $results = [];
+        $args = [
+            'post_type' => 'product',
+            'posts_per_page' => 5,
+            's' => $message,
+            'post_status' => 'publish',
+        ];
+        $query = new WP_Query($args);
+        $brand_attr = $this->get_settings()['wc_brand_attribute'];
+
+        foreach ($query->posts as $post) {
+            $product = wc_get_product($post->ID);
+            if (!$product) continue;
+            if (!empty($keywords)) {
+                $matched = false;
+                $haystack = strtolower($product->get_name() . ' ' . $product->get_short_description() . ' ' . $product->get_description());
+                foreach ($keywords as $kw) {
+                    if (mb_stripos($haystack, $kw) !== false) { $matched = true; break; }
+                }
+                if (!$matched) continue;
+            }
+
+            $price_raw = $product->get_price();
+            $price = $price_raw !== '' ? strip_tags(wc_price($price_raw)) : __('Consultar', 'gpt5-sa');
+            $brands = implode(', ', wc_get_product_terms($product->get_id(), $brand_attr, ['fields' => 'names']));
+            $cats = implode(', ', wc_get_product_terms($product->get_id(), 'product_cat', ['fields' => 'names']));
+            $description = $product->get_short_description();
+            if (!$description) $description = $product->get_description();
+            $description = wp_strip_all_tags($description);
+            if (mb_strlen($description) > 260) {
+                $description = mb_substr($description, 0, 260) . '…';
+            }
+
+            $results[] = sprintf(
+                __('Producto destacado: %1$s | Precio: %2$s | Marca: %3$s | Categorías: %4$s | URL: %5$s | Resumen: %6$s', 'gpt5-sa'),
+                $product->get_name(),
+                $price,
+                $brands ?: __('Sin marca', 'gpt5-sa'),
+                $cats ?: __('Sin categoría', 'gpt5-sa'),
+                get_permalink($product->get_id()),
+                $description ?: __('Sin descripción', 'gpt5-sa')
+            );
+        }
+        wp_reset_postdata();
+        return $results;
+    }
+
+    private function context_from_content($message) {
+        $args = [
+            'post_type' => ['page', 'post'],
+            'posts_per_page' => 4,
+            's' => $message,
+            'post_status' => 'publish',
+        ];
+        $posts = get_posts($args);
+        $context = [];
+        foreach ($posts as $post) {
+            $summary = $post->post_excerpt ?: wp_trim_words(wp_strip_all_tags($post->post_content), 40, '…');
+            $context[] = sprintf(
+                __('Contenido relacionado: %1$s (%2$s) - %3$s', 'gpt5-sa'),
+                get_the_title($post),
+                get_permalink($post),
+                $summary
+            );
+        }
+        return $context;
+    }
+
+    private function build_sitemap_context($keywords) {
+        $entries = $this->get_sitemap_urls();
+        if (empty($entries)) {
+            return [];
+        }
+        $matched = [];
+        foreach ($entries as $entry) {
+            $loc = $entry['loc'];
+            foreach ($keywords as $kw) {
+                if (mb_stripos($loc, $kw) !== false) {
+                    $matched[] = $entry;
+                    break;
+                }
+            }
+        }
+        if (empty($matched)) {
+            $matched = array_slice($entries, 0, 5);
+        }
+        $matched = array_slice($matched, 0, 5);
+        $context = [];
+        foreach ($matched as $entry) {
+            $label = $entry['title'] ? $entry['title'] . ' - ' . $entry['loc'] : $entry['loc'];
+            $context[] = sprintf(
+                __('Mapa del sitio: %1$s (Última actualización: %2$s)', 'gpt5-sa'),
+                $label,
+                $entry['lastmod'] ?: __('N/D', 'gpt5-sa')
+            );
+        }
+        return $context;
+    }
+
+    private function get_sitemap_urls() {
+        $cached = get_transient('gpt5sa_sitemap_cache');
+        if ($cached !== false && is_array($cached)) {
+            return $cached;
+        }
+
+        $urls = [];
+        $candidates = [home_url('/sitemap_index.xml'), home_url('/sitemap.xml')];
+        foreach ($candidates as $candidate) {
+            $response = wp_remote_get($candidate, ['timeout' => 10]);
+            if (is_wp_error($response)) {
+                continue;
+            }
+            $body = wp_remote_retrieve_body($response);
+            if (!$body) {
+                continue;
+            }
+            $xml = @simplexml_load_string($body);
+            if (!$xml) {
+                continue;
+            }
+            if (isset($xml->sitemap)) {
+                foreach ($xml->sitemap as $node) {
+                    $loc = (string) $node->loc;
+                    if (!$loc) continue;
+                    $child = wp_remote_get($loc, ['timeout' => 10]);
+                    if (is_wp_error($child)) continue;
+                    $child_body = wp_remote_retrieve_body($child);
+                    if (!$child_body) continue;
+                    $child_xml = @simplexml_load_string($child_body);
+                    if (!$child_xml || !isset($child_xml->url)) continue;
+                    foreach ($child_xml->url as $url) {
+                        if (count($urls) >= 120) break 3;
+                        $loc_url = (string) $url->loc;
+                        if (!$loc_url) continue;
+                        $urls[] = [
+                            'loc' => $loc_url,
+                            'lastmod' => isset($url->lastmod) ? (string) $url->lastmod : '',
+                            'title' => $this->infer_title_from_url($loc_url),
+                        ];
+                    }
+                }
+            } elseif (isset($xml->url)) {
+                foreach ($xml->url as $url) {
+                    if (count($urls) >= 120) break;
+                    $loc = (string) $url->loc;
+                    if (!$loc) continue;
+                    $urls[] = [
+                        'loc' => $loc,
+                        'lastmod' => isset($url->lastmod) ? (string) $url->lastmod : '',
+                        'title' => $this->infer_title_from_url($loc),
+                    ];
+                }
+            }
+            if (!empty($urls)) {
+                break;
+            }
+        }
+
+        set_transient('gpt5sa_sitemap_cache', $urls, 12 * HOUR_IN_SECONDS);
+        return $urls;
+    }
+
+    private function infer_title_from_url($url) {
+        $parts = wp_parse_url($url);
+        if (!$parts || empty($parts['path'])) {
+            return '';
+        }
+        $segments = array_values(array_filter(explode('/', $parts['path'])));
+        if (empty($segments)) {
+            return '';
+        }
+        $last = end($segments);
+        $last = preg_replace('/\.[a-z0-9]+$/i', '', $last);
+        $last = str_replace(['-', '_'], ' ', $last);
+        $last = trim($last);
+        if ($last === '') {
+            return '';
+        }
+        return mb_convert_case($last, MB_CASE_TITLE, 'UTF-8');
+    }
+
     // -------- Chat (multi-proveedor OpenAI-compatible) --------
     public function route_chat(WP_REST_Request $req) {
         $sec = $this->check_security_headers();
@@ -749,23 +978,30 @@ class GPT5_Shop_Assistant_Onefile {
 
         $max_tokens = intval($opts['max_tokens']);
         $temperature = floatval($opts['temperature']);
-        $model = $opts['model'] ?: 'gpt-4o-mini';
+        $model = $opts['model'] ?: 'gpt-5.1-mini';
+
+        $context_snippets = $this->build_rag_context($message);
 
         if (empty($opts['api_key'])) {
-            if ($stream) { $this->emit_sse_stub($message, $max_tokens); }
-            return new WP_REST_Response(['message' => wp_kses_post($this->generate_reply_stub($message, $max_tokens))]);
+            if ($stream) { $this->emit_sse_stub($message, $max_tokens, $context_snippets); }
+            return new WP_REST_Response(['message' => wp_kses_post($this->generate_reply_stub($message, $max_tokens, $context_snippets))]);
         }
 
         $sys = 'Eres un asistente de compras para WooCommerce. Responde en Markdown y sugiere productos y categorías. Sé breve.';
+        $messages = [
+            ['role'=>'system','content'=>$sys],
+        ];
+        foreach ($context_snippets as $ctx_line) {
+            $messages[] = ['role'=>'system','content'=>'Datos del sitio: '.$ctx_line];
+        }
+        $messages[] = ['role'=>'user','content'=>$message];
+
         $payload = [
             'model' => $model,
             'temperature' => $temperature,
             'max_tokens' => $max_tokens,
             'stream' => $stream ? true : false,
-            'messages' => [
-                ['role'=>'system','content'=>$sys],
-                ['role'=>'user','content'=>$message],
-            ],
+            'messages' => $messages,
         ];
 
         $provider = $opts['provider'];
@@ -788,11 +1024,11 @@ class GPT5_Shop_Assistant_Onefile {
         }
     }
 
-    private function emit_sse_stub($message, $max_tokens){
+    private function emit_sse_stub($message, $max_tokens, $context = []){
         @header('Content-Type: text/event-stream');
         @header('Cache-Control: no-cache');
         @header('Connection: keep-alive');
-        $reply = $this->generate_reply_stub($message, $max_tokens);
+        $reply = $this->generate_reply_stub($message, $max_tokens, $context);
         $tokens = preg_split('/(\s+)/', $reply, -1, PREG_SPLIT_DELIM_CAPTURE);
         foreach ($tokens as $tok) {
             echo 'data: ' . json_encode(['delta' => $tok], JSON_UNESCAPED_UNICODE) . "\n\n";
@@ -905,13 +1141,18 @@ class GPT5_Shop_Assistant_Onefile {
         return null;
     }
 
-    private function generate_reply_stub($message, $max_tokens) {
+    private function generate_reply_stub($message, $max_tokens, $context = []) {
         $suggest = '';
         if (class_exists('WooCommerce')) {
             $url = esc_url( rest_url('gpt5sa/v1/recs') );
             $suggest = sprintf(__(' Mira **Recomendados** o GET %s para sugerencias.', 'gpt5-sa'), $url);
         }
+        $ctx = '';
+        if (!empty($context)) {
+            $ctx = ' ' . sprintf(__('Contexto del sitio: %s.', 'gpt5-sa'), implode(' | ', array_slice($context, 0, 3)));
+        }
         $out = sprintf(__('Ok. Dijiste: “%s”. Puedo buscar productos y sugerirte algunos en base a tus gustos.', 'gpt5-sa'), esc_html($message));
+        $out .= $ctx;
         if (mb_strlen($out) > $max_tokens*4) $out = mb_substr($out, 0, $max_tokens*4) . '…';
         return $out.$suggest;
     }


### PR DESCRIPTION
## Summary
- polish the floating GPT-5 assistant UI with gradient launcher, richer header, and carousel product cards for catalog and recommendations
- surface WooCommerce products, site content, and sitemap insights as retrieval context for GPT-5 conversations and stubs
- default to the gpt-5.1-mini model and propagate richer context into streaming and non-streaming responses

## Testing
- php -l gpt5-shop-assistant-onefile.php

------
https://chatgpt.com/codex/tasks/task_e_68d819ca10f0832493b59408abd5ff5c