### PR TITLE
Add GROUI Smart Assistant plugin

### DIFF
--- a/groui-smart-assistant/README.md
+++ b/groui-smart-assistant/README.md
@@ -1,0 +1,28 @@
+# GROUI Smart Assistant
+
+Plugin de WordPress que crea un asistente flotante con una IA conectada a OpenAI GPT-5, WooCommerce y el sitemap del sitio para recomendar productos, responder preguntas frecuentes y guiar en el proceso de compra.
+
+## Características
+
+- Botón flotante con interfaz oscura y moderna.
+- Chat en vivo impulsado por OpenAI (modelo configurable, por defecto `gpt-5.1`).
+- Indexa páginas, categorías, FAQs, productos y sitemap para construir un contexto propio.
+- Recomienda productos de WooCommerce y muestra las sugerencias en un carrusel.
+- Panel de ajustes en el administrador para definir API Key, modelo y límites de indexado.
+- Actualización automática del contexto mediante cron jobs horarios.
+
+## Requisitos
+
+- WordPress 6.0 o superior.
+- WooCommerce (opcional pero recomendado).
+- Clave de API de OpenAI con acceso al modelo GPT-5.
+
+## Instalación
+
+1. Copia la carpeta `groui-smart-assistant` en `wp-content/plugins/`.
+2. Activa el plugin en el panel de WordPress.
+3. Ve a **GROUI Assistant** en el menú de administración y configura tu API Key y ajustes preferidos.
+
+## Uso
+
+Tras activar el plugin, aparecerá un botón flotante en la esquina inferior derecha del sitio. Haz clic para conversar con la IA, resolver dudas y recibir recomendaciones de productos basadas en WooCommerce.

--- a/groui-smart-assistant/assets/css/groui-smart-assistant.css
+++ b/groui-smart-assistant/assets/css/groui-smart-assistant.css
@@ -1,0 +1,219 @@
+#groui-smart-assistant-root {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.groui-smart-assistant-root .groui-launcher {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c47ff, #ff6fb7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 28px;
+  cursor: pointer;
+  box-shadow: 0 16px 40px rgba(108, 71, 255, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.groui-smart-assistant-root .groui-launcher:hover {
+  transform: translateY(-4px) scale(1.03);
+  box-shadow: 0 20px 50px rgba(255, 111, 183, 0.4);
+}
+
+.groui-smart-assistant-root .groui-chat-panel {
+  position: absolute;
+  bottom: 80px;
+  right: 0;
+  width: 360px;
+  max-height: 520px;
+  background: #0e0d1b;
+  border-radius: 24px;
+  box-shadow: 0 34px 80px rgba(10, 8, 40, 0.65);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: #f9f9ff;
+}
+
+.groui-smart-assistant-root .groui-chat-header {
+  padding: 20px;
+  background: linear-gradient(135deg, #6c47ff, #1f1249);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.groui-smart-assistant-root .groui-chat-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.groui-smart-assistant-root .groui-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.groui-smart-assistant-root .groui-messages {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+  background: radial-gradient(circle at top left, rgba(255, 111, 183, 0.08), transparent 60%);
+}
+
+.groui-smart-assistant-root .groui-message {
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.groui-smart-assistant-root .groui-message.user {
+  text-align: right;
+  color: #c9c9ff;
+}
+
+.groui-smart-assistant-root .groui-message.assistant {
+  background: rgba(108, 71, 255, 0.08);
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 111, 183, 0.15);
+}
+
+.groui-smart-assistant-root .groui-input-area {
+  padding: 16px 20px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 7, 18, 0.95);
+}
+
+.groui-smart-assistant-root .groui-input-area form {
+  display: flex;
+  gap: 12px;
+}
+
+.groui-smart-assistant-root .groui-input-area textarea {
+  flex: 1;
+  resize: none;
+  min-height: 48px;
+  max-height: 120px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fdfdff;
+}
+
+.groui-smart-assistant-root .groui-input-area button {
+  background: linear-gradient(135deg, #ff6fb7, #6c47ff);
+  border: none;
+  border-radius: 14px;
+  padding: 0 20px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  transition: opacity 0.2s ease;
+}
+
+.groui-smart-assistant-root .groui-input-area button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.groui-smart-assistant-root .groui-carousel {
+  padding: 0 20px 18px;
+}
+
+.groui-smart-assistant-root .groui-carousel h4 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  color: #f3f2ff;
+}
+
+.groui-smart-assistant-root .groui-carousel-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 220px;
+  gap: 14px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+}
+
+.groui-smart-assistant-root .groui-product-card {
+  background: rgba(13, 12, 30, 0.85);
+  border: 1px solid rgba(108, 71, 255, 0.2);
+  border-radius: 18px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 240px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.groui-smart-assistant-root .groui-product-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 44px rgba(108, 71, 255, 0.28);
+}
+
+.groui-smart-assistant-root .groui-product-card img {
+  width: 100%;
+  height: 132px;
+  object-fit: cover;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.groui-smart-assistant-root .groui-product-card h5 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fdfdff;
+}
+
+.groui-smart-assistant-root .groui-product-card p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(243, 242, 255, 0.82);
+}
+
+.groui-smart-assistant-root .groui-product-card .groui-price {
+  font-weight: 600;
+  color: #ffd166;
+}
+
+.groui-smart-assistant-root .groui-product-card .groui-actions {
+  margin-top: auto;
+}
+
+.groui-smart-assistant-root .groui-product-card .groui-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6c47ff, #3c2a78);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  #groui-smart-assistant-root {
+    right: 16px;
+    bottom: 16px;
+  }
+
+  .groui-smart-assistant-root .groui-chat-panel {
+    width: calc(100vw - 32px);
+    max-height: 70vh;
+    border-radius: 20px;
+  }
+}

--- a/groui-smart-assistant/assets/js/groui-smart-assistant.js
+++ b/groui-smart-assistant/assets/js/groui-smart-assistant.js
@@ -1,0 +1,258 @@
+(function ($) {
+  const root = document.getElementById('groui-smart-assistant-root');
+  if (!root) {
+    return;
+  }
+
+  const state = {
+    open: false,
+    loading: false,
+    hasWooCommerce: Boolean(GROUISmartAssistant.hasWooCommerce),
+    messages: [],
+  };
+
+  function createTemplate() {
+    root.innerHTML = `
+      <button class="groui-launcher" aria-label="Abrir asistente">
+        <span>🤖</span>
+      </button>
+      <section class="groui-chat-panel" role="dialog" aria-hidden="true">
+        <header class="groui-chat-header">
+          <div>
+            <h3>GROUI Smart Assistant</h3>
+            <small>Conectado a GPT-5 · WooCommerce</small>
+          </div>
+          <button class="groui-close" aria-label="Cerrar">×</button>
+        </header>
+        <div class="groui-messages" data-scroll></div>
+        <div class="groui-carousel" hidden>
+          <h4>Recomendaciones destacadas</h4>
+          <div class="groui-carousel-track" data-carousel></div>
+        </div>
+        <div class="groui-input-area">
+          <form data-form>
+            <textarea name="message" rows="2" placeholder="¿En qué podemos ayudarte?" required></textarea>
+            <button type="submit">Enviar</button>
+          </form>
+        </div>
+      </section>
+    `;
+  }
+
+  function togglePanel(force) {
+    state.open = typeof force === 'boolean' ? force : !state.open;
+    const panel = root.querySelector('.groui-chat-panel');
+    const launcher = root.querySelector('.groui-launcher');
+
+    if (!panel || !launcher) {
+      return;
+    }
+
+    panel.setAttribute('aria-hidden', String(!state.open));
+    panel.style.display = state.open ? 'flex' : 'none';
+    launcher.setAttribute('aria-expanded', String(state.open));
+
+    if (state.open) {
+      panel.querySelector('textarea').focus();
+      if (!state.messages.length) {
+        pushAssistantMessage('Hola, soy tu asistente. Puedo resolver dudas sobre la web, ayudarte con compras y recomendar productos. ¡Pregúntame lo que quieras!');
+      }
+    }
+  }
+
+  function pushUserMessage(content) {
+    state.messages.push({ role: 'user', content });
+    renderMessage({ role: 'user', content });
+  }
+
+  function pushAssistantMessage(content) {
+    state.messages.push({ role: 'assistant', content });
+    renderMessage({ role: 'assistant', content });
+  }
+
+  function renderMessage(message) {
+    const container = root.querySelector('[data-scroll]');
+    if (!container) {
+      return;
+    }
+
+    const div = document.createElement('div');
+    div.className = `groui-message ${message.role}`;
+
+    if (message.role === 'assistant') {
+      div.innerHTML = contentToHtml(message.content);
+    } else {
+      div.textContent = message.content;
+    }
+
+    container.appendChild(div);
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+  }
+
+  function contentToHtml(content) {
+    if (!content) {
+      return '';
+    }
+    return content;
+  }
+
+  function setLoading(isLoading) {
+    state.loading = isLoading;
+    const button = root.querySelector('[data-form] button');
+    const textarea = root.querySelector('[data-form] textarea');
+
+    if (button) {
+      button.disabled = isLoading;
+      button.textContent = isLoading ? 'Pensando…' : 'Enviar';
+    }
+
+    if (textarea && isLoading) {
+      textarea.setAttribute('disabled', 'disabled');
+    } else if (textarea) {
+      textarea.removeAttribute('disabled');
+      textarea.focus();
+    }
+  }
+
+  function renderProducts(products) {
+    const carouselWrapper = root.querySelector('.groui-carousel');
+    const track = root.querySelector('[data-carousel]');
+
+    if (!carouselWrapper || !track) {
+      return;
+    }
+
+    if (!state.hasWooCommerce || !products || !products.length) {
+      carouselWrapper.hidden = true;
+      track.innerHTML = '';
+      return;
+    }
+
+    carouselWrapper.hidden = false;
+    track.innerHTML = products
+      .map(
+        (product) => `
+          <article class="groui-product-card">
+            <img src="${product.image || ''}" alt="${product.name}" loading="lazy" />
+            <h5>${product.name}</h5>
+            <p class="groui-price">${product.price || ''}</p>
+            <p>${product.short_desc || ''}</p>
+            <div class="groui-actions">
+              <a href="${product.permalink}" target="_blank" rel="noopener">
+                Ver detalles
+              </a>
+            </div>
+          </article>
+        `
+      )
+      .join('');
+  }
+
+  function requestProducts(query) {
+    if (!state.hasWooCommerce) {
+      return;
+    }
+
+    $.post(
+      GROUISmartAssistant.ajaxUrl,
+      {
+        action: 'groui_smart_assistant_products',
+        nonce: GROUISmartAssistant.nonce,
+        query: query || '',
+      },
+      (response) => {
+        if (response && response.success && response.data) {
+          renderProducts(response.data.products || []);
+        }
+      }
+    );
+  }
+
+  function submitMessage(content) {
+    setLoading(true);
+    $.post(
+      GROUISmartAssistant.ajaxUrl,
+      {
+        action: 'groui_smart_assistant_chat',
+        nonce: GROUISmartAssistant.nonce,
+        message: content,
+      }
+    )
+      .done((response) => {
+        if (!response || !response.success) {
+          const message = (response && response.data && response.data.message) || 'No se pudo obtener respuesta.';
+          pushAssistantMessage(message);
+          return;
+        }
+
+        if (response.data.answer) {
+          pushAssistantMessage(response.data.answer);
+        }
+
+        if (response.data.productCards) {
+          renderProducts(response.data.productCards);
+        } else if (state.hasWooCommerce) {
+          requestProducts(content);
+        }
+      })
+      .fail((jqXHR) => {
+        let message = 'Error de conexión con el asistente.';
+        if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+          message = jqXHR.responseJSON.data.message;
+        }
+        pushAssistantMessage(message);
+      })
+      .always(() => {
+        setLoading(false);
+      });
+  }
+
+  function bindEvents() {
+    root.addEventListener('click', (event) => {
+      const launcher = root.querySelector('.groui-launcher');
+      const closeBtn = root.querySelector('.groui-close');
+
+      if (event.target === launcher || launcher.contains(event.target)) {
+        togglePanel();
+      }
+
+      if (event.target === closeBtn || (closeBtn && closeBtn.contains(event.target))) {
+        togglePanel(false);
+      }
+    });
+
+    const form = root.querySelector('[data-form]');
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      if (state.loading) {
+        return;
+      }
+
+      const textarea = form.querySelector('textarea');
+      if (!textarea) {
+        return;
+      }
+
+      const value = textarea.value.trim();
+      if (!value) {
+        return;
+      }
+
+      pushUserMessage(value);
+      textarea.value = '';
+      submitMessage(value);
+    });
+  }
+
+  createTemplate();
+  bindEvents();
+  togglePanel(false);
+
+  if (state.hasWooCommerce) {
+    requestProducts('');
+  }
+})(jQuery);

--- a/groui-smart-assistant/groui-smart-assistant.php
+++ b/groui-smart-assistant/groui-smart-assistant.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: GROUI Smart Assistant
+ * Description: Floating AI assistant integrated with OpenAI GPT-5, WooCommerce, and site sitemap data.
+ * Version: 1.0.0
+ * Author: GROUI
+ * Text Domain: groui-smart-assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'GROUI_SMART_ASSISTANT_VERSION' ) ) {
+    define( 'GROUI_SMART_ASSISTANT_VERSION', '1.0.0' );
+}
+
+if ( ! defined( 'GROUI_SMART_ASSISTANT_PATH' ) ) {
+    define( 'GROUI_SMART_ASSISTANT_PATH', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'GROUI_SMART_ASSISTANT_URL' ) ) {
+    define( 'GROUI_SMART_ASSISTANT_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require_once GROUI_SMART_ASSISTANT_PATH . 'includes/class-groui-smart-assistant.php';
+
+function groui_smart_assistant() {
+    return GROUI_Smart_Assistant::instance();
+}
+
+groui_smart_assistant();

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Admin settings for the assistant.
+ *
+ * @package GROUI_Smart_Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GROUI_Smart_Assistant_Admin {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_notices', array( $this, 'maybe_show_missing_key_notice' ) );
+        add_action( 'groui_smart_assistant_refresh_context', array( $this, 'refresh_context_cron' ) );
+    }
+
+    /**
+     * Register plugin menu.
+     */
+    public function register_menu() {
+        add_menu_page(
+            __( 'GROUI Assistant', 'groui-smart-assistant' ),
+            __( 'GROUI Assistant', 'groui-smart-assistant' ),
+            'manage_options',
+            'groui-smart-assistant',
+            array( $this, 'render_settings_page' ),
+            'dashicons-format-chat'
+        );
+    }
+
+    /**
+     * Register settings.
+     */
+    public function register_settings() {
+        register_setting( 'groui-smart-assistant', GROUI_Smart_Assistant::OPTION_KEY, array( $this, 'sanitize_settings' ) );
+
+        add_settings_section(
+            'groui_smart_assistant_general',
+            __( 'Configuración General', 'groui-smart-assistant' ),
+            '__return_false',
+            'groui-smart-assistant'
+        );
+
+        add_settings_field(
+            'openai_api_key',
+            __( 'OpenAI API Key', 'groui-smart-assistant' ),
+            array( $this, 'render_text_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'openai_api_key',
+                'description' => __( 'Introduce tu clave de OpenAI con acceso a GPT-5.', 'groui-smart-assistant' ),
+            )
+        );
+
+        add_settings_field(
+            'model',
+            __( 'Modelo de OpenAI', 'groui-smart-assistant' ),
+            array( $this, 'render_text_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'model',
+                'description' => __( 'Por defecto: gpt-5.1', 'groui-smart-assistant' ),
+            )
+        );
+
+        add_settings_field(
+            'sitemap_url',
+            __( 'URL del sitemap', 'groui-smart-assistant' ),
+            array( $this, 'render_text_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'sitemap_url',
+                'description' => __( 'Se usará para extraer conocimiento de la web.', 'groui-smart-assistant' ),
+            )
+        );
+
+        add_settings_field(
+            'max_pages',
+            __( 'Máximo de páginas a indexar', 'groui-smart-assistant' ),
+            array( $this, 'render_number_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'max_pages',
+                'description' => __( 'Límite de páginas para el contexto.', 'groui-smart-assistant' ),
+                'min'         => 5,
+                'max'         => 50,
+            )
+        );
+
+        add_settings_field(
+            'max_products',
+            __( 'Máximo de productos a indexar', 'groui-smart-assistant' ),
+            array( $this, 'render_number_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'max_products',
+                'description' => __( 'Limita la cantidad de productos que se envían al modelo.', 'groui-smart-assistant' ),
+                'min'         => 5,
+                'max'         => 50,
+            )
+        );
+
+        add_settings_field(
+            'enable_debug',
+            __( 'Habilitar modo depuración', 'groui-smart-assistant' ),
+            array( $this, 'render_checkbox_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'enable_debug',
+                'description' => __( 'Registra información adicional en el log.', 'groui-smart-assistant' ),
+            )
+        );
+    }
+
+    /**
+     * Sanitize settings.
+     *
+     * @param array $settings Raw settings.
+     *
+     * @return array
+     */
+    public function sanitize_settings( $settings ) {
+        $sanitized = array();
+
+        $sanitized['openai_api_key'] = isset( $settings['openai_api_key'] ) ? trim( sanitize_text_field( $settings['openai_api_key'] ) ) : '';
+        $sanitized['model']          = isset( $settings['model'] ) ? trim( sanitize_text_field( $settings['model'] ) ) : 'gpt-5.1';
+        $sanitized['sitemap_url']    = isset( $settings['sitemap_url'] ) ? esc_url_raw( $settings['sitemap_url'] ) : home_url( '/sitemap.xml' );
+        $sanitized['max_pages']      = isset( $settings['max_pages'] ) ? min( 50, max( 5, absint( $settings['max_pages'] ) ) ) : 12;
+        $sanitized['max_products']   = isset( $settings['max_products'] ) ? min( 50, max( 5, absint( $settings['max_products'] ) ) ) : 12;
+        $sanitized['enable_debug']   = ! empty( $settings['enable_debug'] );
+
+        delete_transient( GROUI_Smart_Assistant::CONTEXT_TRANSIENT );
+
+        return $sanitized;
+    }
+
+    /**
+     * Render text field.
+     *
+     * @param array $args Args.
+     */
+    public function render_text_field( $args ) {
+        $options = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+        $value   = isset( $options[ $args['id'] ] ) ? esc_attr( $options[ $args['id'] ] ) : '';
+        printf( '<input type="text" class="regular-text" id="%1$s" name="%2$s[%1$s]" value="%3$s" />', esc_attr( $args['id'] ), esc_attr( GROUI_Smart_Assistant::OPTION_KEY ), $value );
+
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Render number field.
+     *
+     * @param array $args Args.
+     */
+    public function render_number_field( $args ) {
+        $options = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+        $value   = isset( $options[ $args['id'] ] ) ? absint( $options[ $args['id'] ] ) : '';
+        $min     = isset( $args['min'] ) ? absint( $args['min'] ) : 0;
+        $max     = isset( $args['max'] ) ? absint( $args['max'] ) : 100;
+
+        printf(
+            '<input type="number" class="small-text" id="%1$s" name="%2$s[%1$s]" value="%3$s" min="%4$s" max="%5$s" />',
+            esc_attr( $args['id'] ),
+            esc_attr( GROUI_Smart_Assistant::OPTION_KEY ),
+            esc_attr( $value ),
+            esc_attr( $min ),
+            esc_attr( $max )
+        );
+
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Render checkbox field.
+     *
+     * @param array $args Args.
+     */
+    public function render_checkbox_field( $args ) {
+        $options = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+        $value   = ! empty( $options[ $args['id'] ] );
+
+        printf(
+            '<label><input type="checkbox" id="%1$s" name="%2$s[%1$s]" value="1" %3$s /> %4$s</label>',
+            esc_attr( $args['id'] ),
+            esc_attr( GROUI_Smart_Assistant::OPTION_KEY ),
+            checked( $value, true, false ),
+            ! empty( $args['description'] ) ? esc_html( $args['description'] ) : ''
+        );
+    }
+
+    /**
+     * Display settings page.
+     */
+    public function render_settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'GROUI Smart Assistant', 'groui-smart-assistant' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'groui-smart-assistant' );
+                do_settings_sections( 'groui-smart-assistant' );
+                submit_button( __( 'Guardar cambios', 'groui-smart-assistant' ) );
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Show admin notice when API key missing.
+     */
+    public function maybe_show_missing_key_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $settings = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+        if ( empty( $settings['openai_api_key'] ) ) {
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html__( 'GROUI Smart Assistant necesita una API Key de OpenAI para funcionar.', 'groui-smart-assistant' )
+            );
+        }
+    }
+
+    /**
+     * Cron callback to refresh context.
+     */
+    public function refresh_context_cron() {
+        $context = GROUI_Smart_Assistant_Context::instance();
+        $context->refresh_context( true );
+    }
+}

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-context.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-context.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Knowledge context builder for the assistant.
+ *
+ * @package GROUI_Smart_Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GROUI_Smart_Assistant_Context {
+
+    /**
+     * Singleton instance.
+     *
+     * @var GROUI_Smart_Assistant_Context
+     */
+    protected static $instance;
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @return GROUI_Smart_Assistant_Context
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Refresh the cached context.
+     *
+     * @param bool $force Whether to force refresh ignoring cached value.
+     *
+     * @return array
+     */
+    public function refresh_context( $force = false ) {
+        $context = get_transient( GROUI_Smart_Assistant::CONTEXT_TRANSIENT );
+
+        if ( ! $force && false !== $context ) {
+            return $context;
+        }
+
+        $settings = $this->get_settings();
+
+        $context = array(
+            'site'       => get_bloginfo( 'name' ),
+            'tagline'    => get_bloginfo( 'description' ),
+            'sitemap'    => $this->get_sitemap_summary( $settings ),
+            'pages'      => $this->get_page_summaries( $settings['max_pages'] ),
+            'faqs'       => $this->get_faqs_from_content(),
+            'products'   => $this->get_product_summaries( $settings['max_products'] ),
+            'categories' => $this->get_taxonomy_summaries(),
+        );
+
+        set_transient( GROUI_Smart_Assistant::CONTEXT_TRANSIENT, $context, HOUR_IN_SECONDS );
+
+        return $context;
+    }
+
+    /**
+     * Retrieve plugin settings.
+     *
+     * @return array
+     */
+    protected function get_settings() {
+        $defaults = array(
+            'openai_api_key'    => '',
+            'model'             => 'gpt-5.1',
+            'sitemap_url'       => home_url( '/sitemap.xml' ),
+            'enable_debug'      => false,
+            'max_pages'         => 12,
+            'max_products'      => 12,
+        );
+
+        return wp_parse_args( get_option( GROUI_Smart_Assistant::OPTION_KEY, array() ), $defaults );
+    }
+
+    /**
+     * Build sitemap summary.
+     *
+     * @param array $settings Settings.
+     *
+     * @return array
+     */
+    protected function get_sitemap_summary( $settings ) {
+        $sitemap_url = ! empty( $settings['sitemap_url'] ) ? esc_url_raw( $settings['sitemap_url'] ) : home_url( '/sitemap.xml' );
+        $response    = wp_remote_get( $sitemap_url, array( 'timeout' => 15 ) );
+
+        if ( is_wp_error( $response ) ) {
+            return array();
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+
+        if ( empty( $body ) ) {
+            return array();
+        }
+
+        libxml_use_internal_errors( true );
+        $xml = simplexml_load_string( $body );
+        libxml_clear_errors();
+
+        if ( ! $xml ) {
+            return array();
+        }
+
+        $urls = array();
+        foreach ( $xml->url as $entry ) {
+            $loc = isset( $entry->loc ) ? (string) $entry->loc : '';
+            if ( empty( $loc ) ) {
+                continue;
+            }
+
+            $urls[] = array(
+                'url'     => $loc,
+                'lastmod' => isset( $entry->lastmod ) ? (string) $entry->lastmod : '',
+            );
+
+            if ( count( $urls ) >= 20 ) {
+                break;
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Collect page summaries.
+     *
+     * @param int $limit Number of pages to include.
+     *
+     * @return array
+     */
+    protected function get_page_summaries( $limit ) {
+        $pages = get_pages( array(
+            'post_status' => 'publish',
+            'sort_column' => 'menu_order',
+            'number'      => absint( $limit ),
+        ) );
+
+        $summaries = array();
+
+        foreach ( $pages as $page ) {
+            $summaries[] = array(
+                'title'   => $page->post_title,
+                'url'     => get_permalink( $page ),
+                'excerpt' => wp_trim_words( wp_strip_all_tags( $page->post_content ), 55 ),
+            );
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Extract FAQs from content headings.
+     *
+     * @return array
+     */
+    protected function get_faqs_from_content() {
+        $faqs  = array();
+        $posts = get_posts( array(
+            'post_type'      => array( 'page', 'post' ),
+            'posts_per_page' => 20,
+            'post_status'    => 'publish',
+        ) );
+
+        foreach ( $posts as $post ) {
+            preg_match_all( '/<h[2-4][^>]*>(.*?)<\/h[2-4]>/', $post->post_content, $matches );
+            if ( empty( $matches[1] ) ) {
+                continue;
+            }
+
+            foreach ( $matches[1] as $heading ) {
+                $clean = wp_strip_all_tags( $heading );
+                if ( empty( $clean ) ) {
+                    continue;
+                }
+
+                $faqs[] = array(
+                    'question' => $clean,
+                    'source'   => get_permalink( $post ),
+                );
+            }
+        }
+
+        return $faqs;
+    }
+
+    /**
+     * Gather WooCommerce product summaries.
+     *
+     * @param int $limit Number of products to include.
+     *
+     * @return array
+     */
+    protected function get_product_summaries( $limit ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return array();
+        }
+
+        $products = wc_get_products( array(
+            'status' => 'publish',
+            'limit'  => absint( $limit ),
+            'orderby'=> 'date',
+            'order'  => 'DESC',
+        ) );
+
+        $summaries = array();
+
+        foreach ( $products as $product ) {
+            $summaries[] = array(
+                'id'         => $product->get_id(),
+                'name'       => $product->get_name(),
+                'price'      => $product->get_price_html(),
+                'permalink'  => $product->get_permalink(),
+                'image'      => wp_get_attachment_image_url( $product->get_image_id(), 'medium' ),
+                'short_desc' => wp_trim_words( wp_strip_all_tags( $product->get_short_description() ), 30 ),
+                'categories' => array_map( 'intval', $product->get_category_ids() ),
+            );
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Build taxonomy summaries for product categories and brands.
+     *
+     * @return array
+     */
+    protected function get_taxonomy_summaries() {
+        $taxonomies = array( 'product_cat', 'product_tag', 'brand', 'category' );
+        $summary    = array();
+
+        foreach ( $taxonomies as $taxonomy ) {
+            if ( ! taxonomy_exists( $taxonomy ) ) {
+                continue;
+            }
+
+            $terms = get_terms( array(
+                'taxonomy'   => $taxonomy,
+                'hide_empty' => true,
+                'number'     => 20,
+            ) );
+
+            if ( is_wp_error( $terms ) || empty( $terms ) ) {
+                continue;
+            }
+
+            $summary[ $taxonomy ] = array_map(
+                function( $term ) {
+                    return array(
+                        'name'        => $term->name,
+                        'description' => wp_trim_words( $term->description, 25 ),
+                        'url'         => get_term_link( $term ),
+                    );
+                },
+                $terms
+            );
+        }
+
+        return $summary;
+    }
+}

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-frontend.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-frontend.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Frontend assets and AJAX endpoints.
+ *
+ * @package GROUI_Smart_Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GROUI_Smart_Assistant_Frontend {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'wp_footer', array( $this, 'render_widget_container' ) );
+
+        add_action( 'wp_ajax_groui_smart_assistant_chat', array( $this, 'handle_chat_request' ) );
+        add_action( 'wp_ajax_nopriv_groui_smart_assistant_chat', array( $this, 'handle_chat_request' ) );
+
+        add_action( 'wp_ajax_groui_smart_assistant_products', array( $this, 'handle_products_request' ) );
+        add_action( 'wp_ajax_nopriv_groui_smart_assistant_products', array( $this, 'handle_products_request' ) );
+    }
+
+    /**
+     * Enqueue front-end assets.
+     */
+    public function enqueue_assets() {
+        wp_enqueue_style(
+            'groui-smart-assistant',
+            GROUI_SMART_ASSISTANT_URL . 'assets/css/groui-smart-assistant.css',
+            array(),
+            GROUI_SMART_ASSISTANT_VERSION
+        );
+
+        wp_enqueue_script(
+            'groui-smart-assistant',
+            GROUI_SMART_ASSISTANT_URL . 'assets/js/groui-smart-assistant.js',
+            array( 'jquery' ),
+            GROUI_SMART_ASSISTANT_VERSION,
+            true
+        );
+
+        $settings = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+
+        wp_localize_script(
+            'groui-smart-assistant',
+            'GROUISmartAssistant',
+            array(
+                'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
+                'nonce'          => wp_create_nonce( 'groui_smart_assistant_nonce' ),
+                'hasWooCommerce' => class_exists( 'WooCommerce' ),
+                'debug'          => ! empty( $settings['enable_debug'] ),
+            )
+        );
+    }
+
+    /**
+     * Render floating button container in footer.
+     */
+    public function render_widget_container() {
+        echo '<div id="groui-smart-assistant-root" class="groui-smart-assistant-root" aria-live="polite"></div>';
+    }
+
+    /**
+     * Handle chat requests.
+     */
+    public function handle_chat_request() {
+        check_ajax_referer( 'groui_smart_assistant_nonce', 'nonce' );
+
+        $message = isset( $_POST['message'] ) ? sanitize_textarea_field( wp_unslash( $_POST['message'] ) ) : '';
+
+        if ( empty( $message ) ) {
+            wp_send_json_error( array( 'message' => __( 'Escribe una pregunta para continuar.', 'groui-smart-assistant' ) ) );
+        }
+
+        $context = GROUI_Smart_Assistant_Context::instance()->refresh_context();
+        $openai  = new GROUI_Smart_Assistant_OpenAI();
+        $result  = $openai->query( $message, $context );
+
+        if ( is_wp_error( $result ) ) {
+            wp_send_json_error( array(
+                'message' => $result->get_error_message(),
+                'data'    => $result->get_error_data(),
+            ) );
+        }
+
+        $response = array(
+            'answer'   => isset( $result['content']['answer'] ) ? wp_kses_post( $result['content']['answer'] ) : '',
+            'products' => isset( $result['content']['products'] ) ? array_map( 'absint', (array) $result['content']['products'] ) : array(),
+        );
+
+        $response['productCards'] = $this->format_products_for_display( $response['products'], $message );
+
+        wp_send_json_success( $response );
+    }
+
+    /**
+     * Handle explicit product carousel refresh.
+     */
+    public function handle_products_request() {
+        check_ajax_referer( 'groui_smart_assistant_nonce', 'nonce' );
+
+        $query = isset( $_POST['query'] ) ? sanitize_text_field( wp_unslash( $_POST['query'] ) ) : '';
+
+        wp_send_json_success( array(
+            'products' => $this->format_products_for_display( array(), $query ),
+        ) );
+    }
+
+    /**
+     * Prepare product data for the carousel.
+     *
+     * @param array  $product_ids IDs suggested by the model.
+     * @param string $query       Fallback query string.
+     *
+     * @return array
+     */
+    protected function format_products_for_display( $product_ids = array(), $query = '' ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return array();
+        }
+
+        $products = array();
+
+        if ( ! empty( $product_ids ) ) {
+            foreach ( $product_ids as $product_id ) {
+                $product = wc_get_product( $product_id );
+                if ( ! $product instanceof WC_Product ) {
+                    continue;
+                }
+
+                if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+                    continue;
+                }
+
+                $products[ $product_id ] = $product;
+            }
+        }
+
+        if ( empty( $products ) ) {
+            $args = array(
+                'status' => 'publish',
+                'limit'  => 10,
+                'orderby'=> 'popularity',
+            );
+
+            if ( ! empty( $query ) ) {
+                $args['s'] = $query;
+            }
+
+            $products = wc_get_products( $args );
+        }
+
+        $cards = array();
+
+        foreach ( $products as $product ) {
+            $cards[] = array(
+                'id'          => $product->get_id(),
+                'name'        => $product->get_name(),
+                'price'       => wp_strip_all_tags( $product->get_price_html() ),
+                'permalink'   => $product->get_permalink(),
+                'image'       => wp_get_attachment_image_url( $product->get_image_id(), 'medium' ),
+                'short_desc'  => wp_trim_words( wp_strip_all_tags( $product->get_short_description() ), 30 ),
+                'in_stock'    => $product->is_in_stock(),
+            );
+        }
+
+        return $cards;
+    }
+}

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * OpenAI client wrapper.
+ *
+ * @package GROUI_Smart_Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GROUI_Smart_Assistant_OpenAI {
+
+    /**
+     * Send a chat completion request to OpenAI.
+     *
+     * @param string $message User message.
+     * @param array  $context Site context array.
+     *
+     * @return array|WP_Error
+     */
+    public function query( $message, $context ) {
+        $settings = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
+        $api_key  = isset( $settings['openai_api_key'] ) ? trim( $settings['openai_api_key'] ) : '';
+        $model    = ! empty( $settings['model'] ) ? $settings['model'] : 'gpt-5.1';
+
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'missing_api_key', __( 'Falta la API key de OpenAI.', 'groui-smart-assistant' ) );
+        }
+
+        $system_prompt = $this->build_system_prompt( $context );
+
+        $body = array(
+            'model'    => $model,
+            'messages' => array(
+                array(
+                    'role'    => 'system',
+                    'content' => $system_prompt,
+                ),
+                array(
+                    'role'    => 'user',
+                    'content' => $message,
+                ),
+            ),
+            'temperature' => 0.3,
+        );
+
+        $body = apply_filters( 'groui_smart_assistant_openai_body', $body, $message, $context );
+
+        $response = wp_remote_post(
+            'https://api.openai.com/v1/chat/completions',
+            array(
+                'headers' => array(
+                    'Content-Type'  => 'application/json',
+                    'Authorization' => 'Bearer ' . $api_key,
+                ),
+                'timeout' => 30,
+                'body'    => wp_json_encode( $body ),
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( $code >= 400 ) {
+            $message = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Error desconocido en OpenAI.', 'groui-smart-assistant' );
+            return new WP_Error( 'openai_error', $message, $data );
+        }
+
+        if ( empty( $data['choices'][0]['message']['content'] ) ) {
+            return new WP_Error( 'empty_response', __( 'OpenAI no devolvió contenido.', 'groui-smart-assistant' ), $data );
+        }
+
+        $content = $data['choices'][0]['message']['content'];
+        $parsed  = json_decode( $content, true );
+
+        if ( null === $parsed ) {
+            $parsed = array(
+                'answer' => $content,
+            );
+        }
+
+        return array(
+            'raw'     => $data,
+            'content' => $parsed,
+        );
+    }
+
+    /**
+     * Compose system prompt with context data.
+     *
+     * @param array $context Context array.
+     *
+     * @return string
+     */
+    protected function build_system_prompt( $context ) {
+        $instructions = __( 'Eres GROUI Smart Assistant, una IA entrenada con toda la información de este sitio. Usa los datos proporcionados para responder preguntas, guiar procesos de compra y recomendar productos de WooCommerce. Devuelve siempre una respuesta JSON con las claves "answer" (HTML amigable) y "products" (arreglo opcional de IDs de productos de WooCommerce que quieras resaltar). Cuando no tengas información suficiente, sé honesto.', 'groui-smart-assistant' );
+
+        $summary = array(
+            'site'       => isset( $context['site'] ) ? $context['site'] : '',
+            'tagline'    => isset( $context['tagline'] ) ? $context['tagline'] : '',
+            'pages'      => isset( $context['pages'] ) ? $context['pages'] : array(),
+            'faqs'       => isset( $context['faqs'] ) ? $context['faqs'] : array(),
+            'products'   => isset( $context['products'] ) ? $context['products'] : array(),
+            'categories' => isset( $context['categories'] ) ? $context['categories'] : array(),
+            'sitemap'    => isset( $context['sitemap'] ) ? $context['sitemap'] : array(),
+        );
+
+        $summary_text = wp_json_encode( $summary );
+
+        return $instructions . '\n\nContexto:\n' . $summary_text;
+    }
+}

--- a/groui-smart-assistant/includes/class-groui-smart-assistant.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Main plugin bootstrap.
+ *
+ * @package GROUI_Smart_Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GROUI_Smart_Assistant {
+
+    /**
+     * Singleton instance.
+     *
+     * @var GROUI_Smart_Assistant
+     */
+    protected static $instance;
+
+    /**
+     * Plugin settings option key.
+     */
+    const OPTION_KEY = 'groui_smart_assistant_settings';
+
+    /**
+     * Cached context transient key.
+     */
+    const CONTEXT_TRANSIENT = 'groui_smart_assistant_context';
+
+    /**
+     * Initialize singleton instance.
+     *
+     * @return GROUI_Smart_Assistant
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    protected function __construct() {
+        $this->includes();
+        $this->hooks();
+    }
+
+    /**
+     * Include dependencies.
+     */
+    protected function includes() {
+        require_once GROUI_SMART_ASSISTANT_PATH . 'includes/class-groui-smart-assistant-admin.php';
+        require_once GROUI_SMART_ASSISTANT_PATH . 'includes/class-groui-smart-assistant-frontend.php';
+        require_once GROUI_SMART_ASSISTANT_PATH . 'includes/class-groui-smart-assistant-context.php';
+        require_once GROUI_SMART_ASSISTANT_PATH . 'includes/class-groui-smart-assistant-openai.php';
+    }
+
+    /**
+     * Register hooks.
+     */
+    protected function hooks() {
+        register_activation_hook( GROUI_SMART_ASSISTANT_PATH . 'groui-smart-assistant.php', array( $this, 'on_activate' ) );
+        register_deactivation_hook( GROUI_SMART_ASSISTANT_PATH . 'groui-smart-assistant.php', array( $this, 'on_deactivate' ) );
+        add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
+    }
+
+    /**
+     * Initialize plugin pieces.
+     */
+    public function init_plugin() {
+        new GROUI_Smart_Assistant_Admin();
+        new GROUI_Smart_Assistant_Frontend();
+    }
+
+    /**
+     * Activation tasks.
+     */
+    public function on_activate() {
+        if ( ! wp_next_scheduled( 'groui_smart_assistant_refresh_context' ) ) {
+            wp_schedule_event( time(), 'hourly', 'groui_smart_assistant_refresh_context' );
+        }
+
+        // Prime the knowledge context to avoid slow first request.
+        $context = GROUI_Smart_Assistant_Context::instance();
+        $context->refresh_context( true );
+    }
+
+    /**
+     * Deactivation tasks.
+     */
+    public function on_deactivate() {
+        $timestamp = wp_next_scheduled( 'groui_smart_assistant_refresh_context' );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, 'groui_smart_assistant_refresh_context' );
+        }
+
+        delete_transient( self::CONTEXT_TRANSIENT );
+    }
+}


### PR DESCRIPTION
## Summary
- add the GROUI Smart Assistant WordPress plugin bootstrap and activation hooks
- build admin settings, context generation, and OpenAI integration tailored to WooCommerce data and sitemap content
- implement the floating chat UI with product carousel, styling assets, and plugin documentation

## Testing
- `for file in $(find groui-smart-assistant -name '*.php'); do
  php -l "$file" || break
done`


------
https://chatgpt.com/codex/tasks/task_e_68d841fa44a883248630c4600f1bd76d