### PR TITLE
Refresh assistant widget experience

### DIFF
--- a/groui-smart-assistant/assets/css/groui-smart-assistant.css
+++ b/groui-smart-assistant/assets/css/groui-smart-assistant.css
@@ -1,12 +1,13 @@
 :root {
   --gsa-radius: 16px;
   --gsa-radius-lg: 20px;
-  --gsa-shadow: 0 8px 28px rgba(0, 0, 0, .18);
-  --gsa-blur: 12px;
+  --gsa-shadow: 0 18px 42px rgba(4, 6, 28, .38);
+  --gsa-blur: 18px;
   --gsa-accent: #6c5ce7;
   --gsa-accent-600: #5847df;
   --gsa-bg: rgba(20, 20, 26, .78);
   --gsa-surface: rgba(32, 32, 40, .78);
+  --gsa-surface-alt: rgba(54, 54, 68, .52);
   --gsa-text: #f5f7ff;
   --gsa-text-dim: #c8cbe0;
   --gsa-border: rgba(255, 255, 255, .12);
@@ -18,11 +19,12 @@
 @media (prefers-color-scheme: light) {
   :root {
     --gsa-bg: rgba(255, 255, 255, .86);
-    --gsa-surface: rgba(255, 255, 255, .92);
+    --gsa-surface: rgba(255, 255, 255, .94);
+    --gsa-surface-alt: rgba(243, 244, 255, .92);
     --gsa-text: #13151b;
     --gsa-text-dim: #5a6075;
     --gsa-border: rgba(0, 0, 0, .08);
-    --gsa-shadow: 0 12px 28px rgba(0, 0, 0, .12);
+    --gsa-shadow: 0 18px 36px rgba(59, 63, 102, .16);
   }
 }
 
@@ -40,19 +42,32 @@
   border-radius: 50%;
   backdrop-filter: blur(var(--gsa-blur));
   -webkit-backdrop-filter: blur(var(--gsa-blur));
-  background: var(--gsa-bg);
+  background: linear-gradient(135deg, rgba(108, 92, 231, .92), rgba(88, 71, 223, .82));
   border: 1px solid var(--gsa-border);
   box-shadow: var(--gsa-shadow);
   color: var(--gsa-text);
-  display: grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  transition: transform .15s ease, box-shadow .2s ease, background .2s;
+  transition: transform .2s ease, box-shadow .2s ease, filter .3s ease;
   z-index: 9999;
+  position: fixed;
 }
-.gsa-fab:hover { transform: translateY(-1px) scale(1.02); }
+.gsa-fab:hover { transform: translateY(-2px) scale(1.03); filter: brightness(1.04); }
 .gsa-fab:active { transform: scale(.98); }
-.gsa-fab svg { width: 24px; height: 24px; }
+.gsa-fab__icon { position: relative; z-index: 2; display: flex; }
+.gsa-fab svg { width: 26px; height: 26px; }
+.gsa-fab__glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(120% 120% at 50% 10%, rgba(255, 255, 255, .46), transparent);
+  opacity: .9;
+  transition: opacity .3s ease;
+  z-index: 1;
+}
+.gsa-fab:hover .gsa-fab__glow { opacity: 1; }
 
 .gsa-fab__badge {
   position: absolute;
@@ -61,7 +76,7 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--gsa-accent);
+  background: #ff7b7b;
   color: white;
   font: 600 11px/18px ui-sans-serif, system-ui;
   text-align: center;
@@ -89,11 +104,20 @@
   background: var(--gsa-surface);
   border: 1px solid var(--gsa-border);
   box-shadow: var(--gsa-shadow);
+  position: fixed;
 }
 .gsa-window.is-open {
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0) scale(1);
+}
+.gsa-window::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 50% 10%, rgba(255, 255, 255, .08), transparent 55%),
+    linear-gradient(140deg, rgba(108, 92, 231, .06), transparent 45%);
+  pointer-events: none;
 }
 
 .gsa-header {
@@ -103,9 +127,11 @@
   padding: 14px 16px;
   background: linear-gradient(180deg, rgba(0, 0, 0, .04), transparent);
   border-bottom: 1px solid var(--gsa-border);
+  position: relative;
+  z-index: 2;
 }
 .gsa-title { font: 700 15px/1.3 ui-sans-serif, system-ui; color: var(--gsa-text); }
-.gsa-subtitle { font: 500 12px/1.2 ui-sans-serif, system-ui; color: var(--gsa-text-dim); }
+.gsa-subtitle { font: 500 12px/1.2 ui-sans-serif, system-ui; color: var(--gsa-text-dim); margin-top: 2px; }
 .gsa-actions { display: flex; gap: 6px; }
 .gsa-btn {
   appearance: none;
@@ -116,32 +142,50 @@
   border-radius: 12px;
   cursor: pointer;
   transition: background .2s, border-color .2s, transform .12s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 .gsa-btn:hover { background: rgba(255,255,255,.06); }
 .gsa-btn:active { transform: translateY(1px); }
+.gsa-btn svg { width: 16px; height: 16px; }
+.gsa-btn--ghost { border-color: transparent; background: rgba(255, 255, 255, .04); }
+.gsa-btn--ghost:hover { border-color: rgba(255, 255, 255, .16); }
 
 .gsa-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 14px;
+  padding: 18px 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   scroll-behavior: smooth;
+  position: relative;
+  z-index: 1;
 }
 .gsa-msg {
   max-width: 86%;
-  padding: 10px 12px;
-  border-radius: 14px;
-  border: 1px solid var(--gsa-border);
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--gsa-border) 65%, transparent);
   background: rgba(255, 255, 255, .04);
   color: var(--gsa-text);
   backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 6px 18px rgba(2, 12, 32, .12);
 }
-.gsa-msg.user { margin-left: auto; background: rgba(108, 92, 231, .1); border-color: rgba(108, 92, 231, .35); }
+.gsa-msg.user {
+  margin-left: auto;
+  background: linear-gradient(135deg, rgba(108, 92, 231, .28), rgba(88, 71, 223, .22));
+  border-color: rgba(108, 92, 231, .38);
+}
 .gsa-msg.assistant { margin-right: auto; }
-.gsa-msg strong { color: var(--gsa-text); }
-.gsa-msg .muted { color: var(--gsa-text-dim); }
+.gsa-msg strong { color: var(--gsa-text); font-weight: 700; }
+.gsa-msg .muted { color: var(--gsa-text-dim); font-size: 12px; }
+.gsa-msg p { margin: 0; }
+.gsa-msg a { color: inherit; text-decoration: underline; }
 
 .gsa-typing { display: inline-flex; gap: 6px; align-items: center; }
 .gsa-typing-dot {
@@ -160,27 +204,33 @@
 
 .gsa-inputbar {
   border-top: 1px solid var(--gsa-border);
-  padding: 10px;
+  padding: 14px;
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 8px;
-  background: linear-gradient(0deg, rgba(0, 0, 0, .04), transparent);
+  gap: 10px;
+  background: linear-gradient(0deg, rgba(0, 0, 0, .08), transparent);
+  position: relative;
+  z-index: 2;
 }
 .gsa-input {
   width: 100%;
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 12px 12px;
-  background: rgba(255, 255, 255, .06);
+  background: rgba(255, 255, 255, .08);
   color: var(--gsa-text);
   border: 1px solid var(--gsa-border);
   outline: none;
   transition: border-color .2s, background .2s, box-shadow .2s;
+  resize: vertical;
+  min-height: 60px;
+  max-height: 140px;
 }
 .gsa-input::placeholder { color: var(--gsa-text-dim); }
-.gsa-input:focus { border-color: var(--gsa-accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--gsa-accent) 28%, transparent); }
+.gsa-input:focus { border-color: var(--gsa-accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--gsa-accent) 22%, transparent); }
+.gsa-input[disabled] { opacity: .6; cursor: not-allowed; }
 
 .gsa-send {
-  padding: 0 14px;
+  padding: 0 18px;
   border-radius: 12px;
   border: 0;
   background: var(--gsa-accent);
@@ -188,18 +238,43 @@
   font-weight: 600;
   cursor: pointer;
   transition: transform .12s ease, background .2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 .gsa-send:hover { background: var(--gsa-accent-600); }
 .gsa-send:active { transform: translateY(1px); }
+.gsa-send svg { width: 16px; height: 16px; }
+.gsa-send[disabled] { opacity: .6; cursor: not-allowed; }
 
 .gsa-products {
+  margin: 4px 16px 18px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--gsa-border) 70%, transparent);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .07), transparent 65%);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.gsa-products__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.gsa-products__header h4 {
+  margin: 0;
+  font: 700 13px/1.2 ui-sans-serif, system-ui;
+  color: var(--gsa-text);
+  letter-spacing: .01em;
+  text-transform: uppercase;
+}
+.gsa-products__grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  margin-top: 4px;
-}
-@media (max-width: 400px) {
-  .gsa-products { grid-template-columns: 1fr; }
+  gap: 12px;
 }
 
 .gsa-card {
@@ -208,6 +283,9 @@
   border-radius: 14px;
   overflow: hidden;
   transition: transform .12s ease, box-shadow .2s ease, border-color .2s;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
 }
 .gsa-card:hover { transform: translateY(-1px); border-color: rgba(255, 255, 255, .18); }
 .gsa-card__img {
@@ -217,21 +295,44 @@
   display: block;
   background: rgba(255, 255, 255, .06);
 }
-.gsa-card__body { padding: 10px; color: var(--gsa-text); }
+.gsa-card__body { padding: 10px; color: var(--gsa-text); display: flex; flex-direction: column; gap: 8px; flex: 1; }
 .gsa-price { font-weight: 800; margin-top: 4px; }
+.gsa-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.gsa-chip--danger {
+  background: rgba(239, 68, 68, .18);
+  color: #fecaca;
+  border: 1px solid rgba(239, 68, 68, .36);
+}
+.gsa-chip--success {
+  background: rgba(34, 197, 94, .18);
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, .36);
+}
 .gsa-cta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 8px 10px;
   border-radius: 10px;
-  margin-top: 8px;
+  margin-top: auto;
   background: rgba(108, 92, 231, .14);
   color: var(--gsa-text);
   border: 1px solid rgba(108, 92, 231, .32);
   text-decoration: none;
   font-weight: 600;
+  transition: transform .12s ease, border-color .2s ease;
 }
+.gsa-cta:hover { transform: translateY(-1px); border-color: rgba(108, 92, 231, .5); }
+.gsa-cta svg { width: 14px; height: 14px; }
 
 @media (max-width: 480px) {
   .gsa-window {
@@ -243,6 +344,11 @@
     height: auto;
     border-radius: 18px;
   }
+  .gsa-products { margin: 4px 10px 14px; }
+}
+
+@media (max-width: 400px) {
+  .gsa-products__grid { grid-template-columns: 1fr; }
 }
 
 .gsa-hidden { display: none !important; }

--- a/groui-smart-assistant/assets/js/groui-smart-assistant.js
+++ b/groui-smart-assistant/assets/js/groui-smart-assistant.js
@@ -4,59 +4,131 @@
     return;
   }
 
+  const widgetId = 'gsa-dialog';
   const state = {
     open: false,
     loading: false,
     hasWooCommerce: Boolean(GROUISmartAssistant.hasWooCommerce),
     messages: [],
+    badge: 0,
+    greeted: false,
   };
+
+  const SEND_BUTTON_TEMPLATE =
+    '<span>Enviar</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="m3.5 10 13-6-3 6-10 0 10 0 3 6-13-6Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>';
+  const LOADING_BUTTON_TEMPLATE =
+    '<span>Pensando…</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M10 3a7 7 0 1 0 6.2 10.2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /></svg>';
+  const PRODUCT_PLACEHOLDER_IMAGE =
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 160 160'%3E%3Crect width='160' height='160' rx='24' fill='%236c5ce7'/%3E%3Cpath d='M112 56H48a4 4 0 0 0-4 4v60a4 4 0 0 0 4 4h64a4 4 0 0 0 4-4V60a4 4 0 0 0-4-4Zm-4 56H52V64h56v48Z' fill='white' opacity='0.85'/%3E%3Cpath d='M92 48h-24l-4-12h32l-4 12Z' fill='white' opacity='0.85'/%3E%3Ccircle cx='72' cy='92' r='10' fill='%23c8cbe0'/%3E%3Ccircle cx='96' cy='84' r='6' fill='%23c8cbe0'/%3E%3C/svg%3E";
+
+  let typingNode = null;
 
   function createTemplate() {
     root.innerHTML = `
-      <button class="groui-launcher" aria-label="Abrir asistente">
-        <span>🤖</span>
+      <button type="button" class="gsa-fab" aria-label="Abrir asistente" aria-controls="${widgetId}" data-launcher>
+        <span class="gsa-fab__glow" aria-hidden="true"></span>
+        <span class="gsa-fab__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5 11C5 6.582 8.582 3 13 3s8 3.582 8 8c0 4.418-3.582 8-8 8h-1l-3.2 2.4c-.8.6-1.8-.2-1.6-1.1L6.7 17.5C5.6 15.9 5 13.9 5 12v-1Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <circle cx="9.75" cy="11" r="1" fill="currentColor" />
+            <circle cx="13.75" cy="11" r="1" fill="currentColor" />
+            <path d="M12 14.5c.8 0 1.5-.4 2-.9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+          </svg>
+        </span>
+        <span class="gsa-fab__badge gsa-hidden" data-badge>1</span>
       </button>
-      <section class="groui-chat-panel" role="dialog" aria-hidden="true">
-        <header class="groui-chat-header">
+      <section class="gsa-window" id="${widgetId}" role="dialog" aria-modal="false" aria-hidden="true" aria-label="Asistente virtual">
+        <header class="gsa-header">
           <div>
-            <h3>GROUI Smart Assistant</h3>
-            <small>Conectado a GPT-5 · WooCommerce</small>
+            <p class="gsa-title">GROUI Smart Assistant</p>
+            <p class="gsa-subtitle">Tu copiloto para explorar la tienda</p>
           </div>
-          <button class="groui-close" aria-label="Cerrar">×</button>
+          <div class="gsa-actions">
+            <button type="button" class="gsa-btn" data-refresh title="Actualizar recomendaciones">
+              <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M4.5 4.5a6.5 6.5 0 0 1 11 3.5h1.5a.5.5 0 0 1 .4.8l-2.3 3a.5.5 0 0 1-.8 0l-2.3-3a.5.5 0 0 1 .4-.8H14a5 5 0 0 0-9-2.7.75.75 0 0 1-1.24-.83l.74-1.17Zm11 11a6.5 6.5 0 0 1-11-3.5H3a.5.5 0 0 1-.4-.8l2.3-3a.5.5 0 0 1 .8 0l2.3 3a.5.5 0 0 1-.4.8H6a5 5 0 0 0 9 2.7.75.75 0 0 1 1.24.83l-.74 1.17Z" fill="currentColor"/>
+              </svg>
+              <span class="gsa-visually-hidden">Actualizar recomendaciones</span>
+            </button>
+            <button type="button" class="gsa-btn" data-close title="Cerrar asistente">
+              <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="m6 6 8 8M6 14 14 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+              <span class="gsa-visually-hidden">Cerrar asistente</span>
+            </button>
+          </div>
         </header>
-        <div class="groui-messages" data-scroll></div>
-        <div class="groui-carousel" hidden>
-          <h4>Recomendaciones destacadas</h4>
-          <div class="groui-carousel-track" data-carousel></div>
-        </div>
-        <div class="groui-input-area">
-          <form data-form>
-            <textarea name="message" rows="2" placeholder="¿En qué podemos ayudarte?" required></textarea>
-            <button type="submit">Enviar</button>
-          </form>
-        </div>
+        <div class="gsa-messages" data-scroll></div>
+        <section class="gsa-products gsa-hidden" data-products-section>
+          <div class="gsa-products__header">
+            <h4>Recomendaciones destacadas</h4>
+            <button type="button" class="gsa-btn gsa-btn--ghost" data-refresh-secondary>
+              <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M4.5 4.5a6.5 6.5 0 0 1 11 3.5h1.5a.5.5 0 0 1 .4.8l-2.3 3a.5.5 0 0 1-.8 0l-2.3-3a.5.5 0 0 1 .4-.8H14a5 5 0 0 0-9-2.7.75.75 0 0 1-1.24-.83l.74-1.17Zm11 11a6.5 6.5 0 0 1-11-3.5H3a.5.5 0 0 1-.4-.8l2.3-3a.5.5 0 0 1 .8 0l2.3 3a.5.5 0 0 1-.4.8H6a5 5 0 0 0 9 2.7.75.75 0 0 1 1.24.83l-.74 1.17Z" fill="currentColor"/>
+              </svg>
+              <span>Actualizar</span>
+            </button>
+          </div>
+          <div class="gsa-products__grid" data-products-grid></div>
+        </section>
+        <form class="gsa-inputbar" data-form>
+          <label for="gsa-message" class="gsa-visually-hidden">Escribe tu mensaje</label>
+          <textarea id="gsa-message" class="gsa-input" name="message" rows="2" placeholder="Cuéntame qué necesitas…" required></textarea>
+          <button type="submit" class="gsa-send">
+            ${SEND_BUTTON_TEMPLATE}
+          </button>
+        </form>
       </section>
     `;
   }
 
+  function updateBadge(count) {
+    const badge = root.querySelector('[data-badge]');
+    if (!badge) {
+      return;
+    }
+
+    if (count > 0) {
+      badge.textContent = count > 9 ? '9+' : String(count);
+      badge.classList.remove('gsa-hidden');
+    } else {
+      badge.classList.add('gsa-hidden');
+    }
+  }
+
   function togglePanel(force) {
     state.open = typeof force === 'boolean' ? force : !state.open;
-    const panel = root.querySelector('.groui-chat-panel');
-    const launcher = root.querySelector('.groui-launcher');
+    const panel = root.querySelector('.gsa-window');
+    const launcher = root.querySelector('[data-launcher]');
 
     if (!panel || !launcher) {
       return;
     }
 
+    panel.classList.toggle('is-open', state.open);
     panel.setAttribute('aria-hidden', String(!state.open));
-    panel.style.display = state.open ? 'flex' : 'none';
     launcher.setAttribute('aria-expanded', String(state.open));
 
     if (state.open) {
-      panel.querySelector('textarea').focus();
-      if (!state.messages.length) {
-        pushAssistantMessage('Hola, soy tu asistente. Puedo resolver dudas sobre la web, ayudarte con compras y recomendar productos. ¡Pregúntame lo que quieras!');
+      state.badge = 0;
+      updateBadge(state.badge);
+      const textarea = root.querySelector('[data-form] textarea');
+      if (textarea) {
+        setTimeout(() => textarea.focus(), 100);
       }
+      if (!state.greeted) {
+        state.greeted = true;
+        pushAssistantMessage(
+          '<strong>¡Hola! 👋</strong><p class="muted">Estoy lista para resolver dudas, guiarte por la web y recomendar productos especiales para ti.</p>'
+        );
+      }
+    }
+  }
+
+  function scrollMessages() {
+    const container = root.querySelector('[data-scroll]');
+    if (container) {
+      container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
     }
   }
 
@@ -66,8 +138,13 @@
   }
 
   function pushAssistantMessage(content) {
+    hideTypingIndicator();
     state.messages.push({ role: 'assistant', content });
     renderMessage({ role: 'assistant', content });
+    if (!state.open) {
+      state.badge += 1;
+      updateBadge(state.badge);
+    }
   }
 
   function renderMessage(message) {
@@ -77,7 +154,7 @@
     }
 
     const div = document.createElement('div');
-    div.className = `groui-message ${message.role}`;
+    div.className = `gsa-msg ${message.role}`;
 
     if (message.role === 'assistant') {
       div.innerHTML = contentToHtml(message.content);
@@ -86,7 +163,7 @@
     }
 
     container.appendChild(div);
-    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+    scrollMessages();
   }
 
   function contentToHtml(content) {
@@ -96,6 +173,49 @@
     return content;
   }
 
+  function escapeAttribute(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;');
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function showTypingIndicator() {
+    if (typingNode) {
+      return;
+    }
+    const container = root.querySelector('[data-scroll]');
+    if (!container) {
+      return;
+    }
+    typingNode = document.createElement('div');
+    typingNode.className = 'gsa-msg assistant';
+    typingNode.innerHTML = `
+      <span class="gsa-typing" aria-label="El asistente está escribiendo">
+        <span class="gsa-typing-dot"></span>
+        <span class="gsa-typing-dot"></span>
+        <span class="gsa-typing-dot"></span>
+      </span>
+    `;
+    container.appendChild(typingNode);
+    scrollMessages();
+  }
+
+  function hideTypingIndicator() {
+    if (!typingNode) {
+      return;
+    }
+    typingNode.remove();
+    typingNode = null;
+  }
+
   function setLoading(isLoading) {
     state.loading = isLoading;
     const button = root.querySelector('[data-form] button');
@@ -103,48 +223,69 @@
 
     if (button) {
       button.disabled = isLoading;
-      button.textContent = isLoading ? 'Pensando…' : 'Enviar';
+      button.innerHTML = isLoading ? LOADING_BUTTON_TEMPLATE : SEND_BUTTON_TEMPLATE;
     }
 
-    if (textarea && isLoading) {
-      textarea.setAttribute('disabled', 'disabled');
-    } else if (textarea) {
-      textarea.removeAttribute('disabled');
-      textarea.focus();
+    if (textarea) {
+      if (isLoading) {
+        textarea.setAttribute('disabled', 'disabled');
+        showTypingIndicator();
+      } else {
+        textarea.removeAttribute('disabled');
+        if (state.open) {
+          textarea.focus();
+        }
+        hideTypingIndicator();
+      }
     }
   }
 
   function renderProducts(products) {
-    const carouselWrapper = root.querySelector('.groui-carousel');
-    const track = root.querySelector('[data-carousel]');
+    const section = root.querySelector('[data-products-section]');
+    const grid = root.querySelector('[data-products-grid]');
 
-    if (!carouselWrapper || !track) {
+    if (!section || !grid) {
       return;
     }
 
     if (!state.hasWooCommerce || !products || !products.length) {
-      carouselWrapper.hidden = true;
-      track.innerHTML = '';
+      section.classList.add('gsa-hidden');
+      grid.innerHTML = '';
       return;
     }
 
-    carouselWrapper.hidden = false;
-    track.innerHTML = products
-      .map(
-        (product) => `
-          <article class="groui-product-card">
-            <img src="${product.image || ''}" alt="${product.name}" loading="lazy" />
-            <h5>${product.name}</h5>
-            <p class="groui-price">${product.price || ''}</p>
-            <p>${product.short_desc || ''}</p>
-            <div class="groui-actions">
-              <a href="${product.permalink}" target="_blank" rel="noopener">
+    section.classList.remove('gsa-hidden');
+    grid.innerHTML = products
+      .map((product) => {
+        const statusChip = product.in_stock
+          ? '<span class="gsa-chip gsa-chip--success">En stock</span>'
+          : '<span class="gsa-chip gsa-chip--danger">Agotado</span>';
+        const description = product.short_desc ? `<p>${escapeHtml(product.short_desc)}</p>` : '';
+        const imageSrc = product.image || PRODUCT_PLACEHOLDER_IMAGE;
+        const altText = escapeAttribute(product.name);
+        const permalink = escapeAttribute(product.permalink);
+        const productName = escapeHtml(product.name);
+        const productPrice = escapeHtml(product.price || '');
+        return `
+          <article class="gsa-card">
+            <img src="${imageSrc}" alt="${altText}" class="gsa-card__img" loading="lazy" />
+            <div class="gsa-card__body">
+              <div>
+                <h5>${productName}</h5>
+                <p class="gsa-price">${productPrice}</p>
+              </div>
+              ${statusChip}
+              ${description}
+              <a class="gsa-cta" href="${permalink}" target="_blank" rel="noopener">
+                <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M6 14 14 6m0 0H7m7 0v7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
                 Ver detalles
               </a>
             </div>
           </article>
-        `
-      )
+        `;
+      })
       .join('');
   }
 
@@ -209,16 +350,25 @@
 
   function bindEvents() {
     root.addEventListener('click', (event) => {
-      const launcher = root.querySelector('.groui-launcher');
-      const closeBtn = root.querySelector('.groui-close');
+      const launcher = root.querySelector('[data-launcher]');
+      const closeBtn = root.querySelector('[data-close]');
+      const refreshButtons = root.querySelectorAll('[data-refresh], [data-refresh-secondary]');
 
-      if (event.target === launcher || launcher.contains(event.target)) {
+      if (launcher && (event.target === launcher || launcher.contains(event.target))) {
         togglePanel();
+        return;
       }
 
-      if (event.target === closeBtn || (closeBtn && closeBtn.contains(event.target))) {
+      if (closeBtn && (event.target === closeBtn || closeBtn.contains(event.target))) {
         togglePanel(false);
+        return;
       }
+
+      refreshButtons.forEach((button) => {
+        if (event.target === button || button.contains(event.target)) {
+          requestProducts('');
+        }
+      });
     });
 
     const form = root.querySelector('[data-form]');
@@ -256,34 +406,3 @@
     requestProducts('');
   }
 })(jQuery);
-
-(function() {
-  const root = document.getElementById('groui-smart-assistant-root');
-  if (!root) return;
-  // Assign modern UI classes to existing elements
-  const launcher = root.querySelector('.groui-launcher');
-  if (launcher) launcher.classList.add('gsa-fab');
-  const panel = root.querySelector('.groui-chat-panel');
-  if (panel) panel.classList.add('gsa-window');
-  const header = panel ? panel.querySelector('.groui-chat-header') : null;
-  if (header) header.classList.add('gsa-header');
-  const messages = panel ? panel.querySelector('.groui-messages') : null;
-  if (messages) messages.classList.add('gsa-messages');
-  const inputBar = panel ? panel.querySelector('.groui-input-area') : null;
-  if (inputBar) inputBar.classList.add('gsa-inputbar');
-  const textarea = inputBar ? inputBar.querySelector('textarea') : null;
-  if (textarea) {
-    textarea.classList.add('gsa-input');
-  }
-  const sendBtn = inputBar ? inputBar.querySelector('button') : null;
-  if (sendBtn) sendBtn.classList.add('gsa-send');
-  const carousel = panel ? panel.querySelector('.groui-carousel') : null;
-  if (carousel) carousel.classList.add('gsa-products');
-  // Automatically scroll to bottom when new messages are added
-  const scrollToEnd = () => {
-    if (messages) messages.scrollTop = messages.scrollHeight;
-  };
-  const observer = new MutationObserver(scrollToEnd);
-  if (messages) observer.observe(messages, { childList: true, subtree: true });
-  scrollToEnd();
-})();


### PR DESCRIPTION
## Summary
- redesign the floating launcher and chat panel with updated gradients, spacing, and interactive states
- rebuild the widget markup and scripting to render the modern layout, typing indicator, and notification badge directly
- enhance product carousel rendering with sanitized content, badges, and placeholder imagery

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9ae9725e883249d6867957fee0405