### PR TITLE
Tweak recommendation cadence and rely on default temperature

### DIFF
--- a/groui-smart-assistant/README.md
+++ b/groui-smart-assistant/README.md
@@ -5,7 +5,7 @@ Plugin de WordPress que crea un asistente flotante con una IA conectada a OpenAI
 ## Características
 
 - Botón flotante con interfaz oscura y moderna.
-- Chat en vivo impulsado por OpenAI (modelo configurable, por defecto `gpt-5.1`).
+- Chat en vivo impulsado por OpenAI (modelo configurable, por defecto `gpt-5`).
 - Indexa páginas, categorías, FAQs, productos y sitemap para construir un contexto propio.
 - Recomienda productos de WooCommerce y muestra las sugerencias en un carrusel.
 - Panel de ajustes en el administrador para definir API Key, modelo y límites de indexado.
@@ -26,3 +26,10 @@ Plugin de WordPress que crea un asistente flotante con una IA conectada a OpenAI
 ## Uso
 
 Tras activar el plugin, aparecerá un botón flotante en la esquina inferior derecha del sitio. Haz clic para conversar con la IA, resolver dudas y recibir recomendaciones de productos basadas en WooCommerce.
+
+### Selección del modelo GPT-5
+
+- El campo **Modelo de OpenAI** acepta los modelos de la familia GPT-5 publicados por OpenAI: `gpt-5`, `gpt-5-mini` y `gpt-5-nano`.
+- El nombre del modelo es sensible a mayúsculas/minúsculas y a espacios. El plugin normaliza entradas comunes como `GPT 5 mini` o `gPt-5` para enviarlas correctamente.
+- Si aparece el error “The model `GPT-5` does not exist or you do not have access to it”, revisa que el nombre coincida exactamente con uno de los anteriores y que tu cuenta tenga acceso activo al plan correspondiente.
+- Puedes extender la lista de modelos permitidos usando el filtro `groui_smart_assistant_allowed_models` si OpenAI publica nuevas variantes compatibles.

--- a/groui-smart-assistant/assets/css/groui-smart-assistant.css
+++ b/groui-smart-assistant/assets/css/groui-smart-assistant.css
@@ -158,10 +158,15 @@
   padding: 18px 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   scroll-behavior: smooth;
   position: relative;
   z-index: 1;
+}
+.gsa-messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 .gsa-msg {
   max-width: 86%;

--- a/groui-smart-assistant/assets/js/groui-smart-assistant.js
+++ b/groui-smart-assistant/assets/js/groui-smart-assistant.js
@@ -58,19 +58,21 @@
             </button>
           </div>
         </header>
-        <div class="gsa-messages" data-scroll></div>
-        <section class="gsa-products gsa-hidden" data-products-section>
-          <div class="gsa-products__header">
-            <h4>Recomendaciones destacadas</h4>
-            <button type="button" class="gsa-btn gsa-btn--ghost" data-refresh-secondary>
-              <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <path d="M4.5 4.5a6.5 6.5 0 0 1 11 3.5h1.5a.5.5 0 0 1 .4.8l-2.3 3a.5.5 0 0 1-.8 0l-2.3-3a.5.5 0 0 1 .4-.8H14a5 5 0 0 0-9-2.7.75.75 0 0 1-1.24-.83l.74-1.17Zm11 11a6.5 6.5 0 0 1-11-3.5H3a.5.5 0 0 1-.4-.8l2.3-3a.5.5 0 0 1 .8 0l2.3 3a.5.5 0 0 1-.4.8H6a5 5 0 0 0 9 2.7.75.75 0 0 1 1.24.83l-.74 1.17Z" fill="currentColor"/>
-              </svg>
-              <span>Actualizar</span>
-            </button>
-          </div>
-          <div class="gsa-products__grid" data-products-grid></div>
-        </section>
+        <div class="gsa-messages" data-scroll>
+          <div class="gsa-messages__list" data-messages></div>
+          <section class="gsa-products gsa-hidden" data-products-section>
+            <div class="gsa-products__header">
+              <h4>Recomendaciones destacadas</h4>
+              <button type="button" class="gsa-btn gsa-btn--ghost" data-refresh-secondary>
+                <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M4.5 4.5a6.5 6.5 0 0 1 11 3.5h1.5a.5.5 0 0 1 .4.8l-2.3 3a.5.5 0 0 1-.8 0l-2.3-3a.5.5 0 0 1 .4-.8H14a5 5 0 0 0-9-2.7.75.75 0 0 1-1.24-.83l.74-1.17Zm11 11a6.5 6.5 0 0 1-11-3.5H3a.5.5 0 0 1-.4-.8l2.3-3a.5.5 0 0 1 .8 0l2.3 3a.5.5 0 0 1-.4.8H6a5 5 0 0 0 9 2.7.75.75 0 0 1 1.24.83l-.74 1.17Z" fill="currentColor"/>
+                </svg>
+                <span>Actualizar</span>
+              </button>
+            </div>
+            <div class="gsa-products__grid" data-products-grid></div>
+          </section>
+        </div>
         <form class="gsa-inputbar" data-form>
           <label for="gsa-message" class="gsa-visually-hidden">Escribe tu mensaje</label>
           <textarea id="gsa-message" class="gsa-input" name="message" rows="2" placeholder="Cuéntame qué necesitas…" required></textarea>
@@ -147,8 +149,12 @@
     }
   }
 
+  function getMessagesContainer() {
+    return root.querySelector('[data-messages]') || root.querySelector('[data-scroll]');
+  }
+
   function renderMessage(message) {
-    const container = root.querySelector('[data-scroll]');
+    const container = getMessagesContainer();
     if (!container) {
       return;
     }
@@ -191,7 +197,7 @@
     if (typingNode) {
       return;
     }
-    const container = root.querySelector('[data-scroll]');
+    const container = getMessagesContainer();
     if (!container) {
       return;
     }
@@ -287,6 +293,8 @@
         `;
       })
       .join('');
+
+    scrollMessages();
   }
 
   function requestProducts(query) {
@@ -330,10 +338,14 @@
           pushAssistantMessage(response.data.answer);
         }
 
-        if (response.data.productCards) {
-          renderProducts(response.data.productCards);
-        } else if (state.hasWooCommerce) {
-          requestProducts(content);
+        if (
+          state.hasWooCommerce &&
+          Object.prototype.hasOwnProperty.call(response.data, 'productCards')
+        ) {
+          const cards = Array.isArray(response.data.productCards)
+            ? response.data.productCards
+            : [];
+          renderProducts(cards);
         }
       })
       .fail((jqXHR) => {
@@ -402,7 +414,5 @@
   bindEvents();
   togglePanel(false);
 
-  if (state.hasWooCommerce) {
-    requestProducts('');
-  }
+  // Product recommendations are now opt-in via the refresh button or explicit assistant responses.
 })(jQuery);

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
@@ -31,7 +31,17 @@ class GROUI_Smart_Assistant_OpenAI {
     public function query( $message, $context ) {
         $settings = get_option( GROUI_Smart_Assistant::OPTION_KEY, array() );
         $api_key  = isset( $settings['openai_api_key'] ) ? trim( $settings['openai_api_key'] ) : '';
-        $model    = ! empty( $settings['model'] ) ? $settings['model'] : 'ggpt-5';
+        $model    = isset( $settings['model'] ) ? $settings['model'] : '';
+        $model    = $this->normalize_model( $model );
+
+        $allowed_models = apply_filters(
+            'groui_smart_assistant_allowed_models',
+            array( 'gpt-5', 'gpt-5-mini', 'gpt-5-nano' )
+        );
+
+        if ( empty( $model ) || ( ! empty( $allowed_models ) && ! in_array( $model, $allowed_models, true ) ) ) {
+            $model = 'gpt-5';
+        }
 
         if ( empty( $api_key ) ) {
             return new WP_Error( 'missing_api_key', __( 'Falta la API key de OpenAI.', 'groui-smart-assistant' ) );
@@ -51,7 +61,6 @@ class GROUI_Smart_Assistant_OpenAI {
                     'content' => $message,
                 ),
             ),
-            'temperature' => 0.3,
         );
 
         /**
@@ -88,6 +97,11 @@ class GROUI_Smart_Assistant_OpenAI {
         // Handle HTTP errors returned by the API.
         if ( $code >= 400 ) {
             $message = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Error desconocido en OpenAI.', 'groui-smart-assistant' );
+
+            if ( false !== stripos( $message, 'model' ) && false !== stripos( $message, 'does not exist' ) ) {
+                $hint     = __( 'Verifica que el nombre del modelo sea exactamente gpt-5, gpt-5-mini o gpt-5-nano y que tu cuenta tenga acceso activo.', 'groui-smart-assistant' );
+                $message .= ' ' . $hint;
+            }
             return new WP_Error( 'openai_error', $message, $data );
         }
 
@@ -141,5 +155,24 @@ class GROUI_Smart_Assistant_OpenAI {
 
         // Use real newlines within the string to avoid double escaping.
         return $instructions . "\n\nContexto:\n" . $summary_text;
+    }
+
+    /**
+     * Normalize the configured model name.
+     *
+     * Ensures the value is lowercase, trimmed and uses hyphens for
+     * whitespace so that values such as "GPT 5" become "gpt-5" before the
+     * request is sent to OpenAI.
+     *
+     * @param string $model Raw model string stored in settings.
+     *
+     * @return string Normalized model identifier.
+     */
+    protected function normalize_model( $model ) {
+        $model = strtolower( trim( (string) $model ) );
+        $model = preg_replace( '/\s+/', '-', $model );
+        $model = preg_replace( '/[^a-z0-9\-.]/', '', $model );
+
+        return $model;
     }
 }


### PR DESCRIPTION
## Summary
- stop auto-refreshing WooCommerce product recommendations on every user turn and only render cards when the assistant explicitly returns them
- remove the unsupported temperature override from the OpenAI request payload so GPT-5 models fall back to the default value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b2002fcc8324b1cbd5f3c180c3b9