### PR TITLE
Add filter to adjust OpenAI request arguments

### DIFF
--- a/groui-smart-assistant/README.md
+++ b/groui-smart-assistant/README.md
@@ -27,6 +27,10 @@ Plugin de WordPress que crea un asistente flotante con una IA conectada a OpenAI
 
 Tras activar el plugin, aparecerá un botón flotante en la esquina inferior derecha del sitio. Haz clic para conversar con la IA, resolver dudas y recibir recomendaciones de productos basadas en WooCommerce.
 
+## Filtros disponibles
+
+- `groui_smart_assistant_openai_request_args`: Permite modificar los argumentos enviados a `wp_remote_post()` antes de contactar con OpenAI. Úsalo para añadir cabeceras personalizadas o ajustar el `timeout` (por defecto 60 s) cuando necesites respuestas más largas sin editar el código del plugin.
+
 ### Selección del modelo GPT-5
 
 - El campo **Modelo de OpenAI** acepta los modelos de la familia GPT-5 publicados por OpenAI: `gpt-5`, `gpt-5-mini` y `gpt-5-nano`.

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
@@ -76,16 +76,32 @@ class GROUI_Smart_Assistant_OpenAI {
          */
         $body = apply_filters( 'groui_smart_assistant_openai_body', $body, $message, $context );
 
+        $request_args = array(
+            'headers' => array(
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ),
+            'timeout' => 60,
+            'body'    => wp_json_encode( $body ),
+        );
+
+        /**
+         * Filter the request arguments before sending to OpenAI.
+         *
+         * Developers can tweak headers, increase the timeout, or alter any
+         * other `wp_remote_post()` parameter via this filter. The default
+         * timeout is 60 seconds to accommodate longer running completions.
+         *
+         * @param array  $request_args HTTP request arguments passed to `wp_remote_post()`.
+         * @param array  $body         Prepared request payload that will be JSON encoded.
+         * @param string $message      Original user message.
+         * @param array  $context      Built site context.
+         */
+        $request_args = apply_filters( 'groui_smart_assistant_openai_request_args', $request_args, $body, $message, $context );
+
         $response = wp_remote_post(
             'https://api.openai.com/v1/chat/completions',
-            array(
-                'headers' => array(
-                    'Content-Type'  => 'application/json',
-                    'Authorization' => 'Bearer ' . $api_key,
-                ),
-                'timeout' => 30,
-                'body'    => wp_json_encode( $body ),
-            )
+            $request_args
         );
 
         if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
## Summary
- wrap the OpenAI `wp_remote_post()` arguments in a new `groui_smart_assistant_openai_request_args` filter
- increase the default OpenAI timeout to 60 seconds to support longer completions
- document the new filter so site owners can override headers or timeout without editing core files

## Testing
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-openai.php

------
https://chatgpt.com/codex/tasks/task_e_68df052a46848324afb2e3b48a13c8bb