### PR TITLE
Allow unlimited indexing and clarify settings

### DIFF
--- a/groui-smart-assistant/README.md
+++ b/groui-smart-assistant/README.md
@@ -45,6 +45,10 @@ Tras activar el plugin, aparecerá un botón flotante en la esquina inferior der
 - `groui_smart_assistant_context_maximum_pages`: Establece un tope al número de páginas cargadas en modo de contexto completo (por defecto ilimitado).
 - `groui_smart_assistant_context_maximum_terms`: Fija un máximo de términos por taxonomía cuando se recorre el catálogo completo (por defecto ilimitado).
 
+### Límites de indexado
+
+- En los campos **Máximo de páginas a indexar** y **Máximo de productos a indexar** puedes introducir `0` para desactivar el límite y cargar absolutamente todo el contenido disponible. El asistente conservará igualmente la opción de limitar por relevancia cuando lo necesites.
+
 ### Búsqueda profunda y modo de contexto completo
 
 - En la página de ajustes encontrarás el checkbox **Modo de contexto completo**. Al activarlo, la IA recibirá todas las páginas, productos, FAQs, categorías y URLs recopiladas sin aplicar el recorte por relevancia; además, ahora el contexto se construye en lotes para evitar picos de memoria mientras recorre catálogos grandes, elevando automáticamente los límites de tiempo/memoria cuando sea necesario. El modo profundo cargará el catálogo completo de WooCommerce y consultará todas las páginas publicadas, entradas para FAQs y términos de las taxonomías incluidas (salvo que limites las cifras con los filtros anteriores o los nuevos topes por página/término) para que las respuestas puedan hacer referencia a todo tu contenido publicado.

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
@@ -395,7 +395,19 @@ class GROUI_Smart_Assistant_OpenAI {
      * @return int Normalised limit value.
      */
     protected function normalize_limit( $requested, $entries ) {
-        $limit = max( 1, absint( $requested ) );
+        $requested = (int) $requested;
+
+        if ( $requested <= 0 ) {
+            if ( is_array( $entries ) ) {
+                $count = count( $entries );
+
+                return ( $count > 0 ) ? $count : 1;
+            }
+
+            return 1;
+        }
+
+        $limit = $requested;
 
         if ( is_array( $entries ) ) {
             $count = count( $entries );
@@ -405,7 +417,7 @@ class GROUI_Smart_Assistant_OpenAI {
             }
         }
 
-        return $limit;
+        return max( 1, $limit );
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow the context builder to treat zero or negative limits as unlimited when fetching pages, posts and products
- update admin settings to accept 0 as "sin límite", persist the value correctly and document the behaviour in the README
- adjust OpenAI context refinement limits so unlimited settings keep the full catalogue available for answers

## Testing
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-context.php
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-openai.php


------
https://chatgpt.com/codex/tasks/task_e_68df6798aa48832497387ce4991b59c7