### PR TITLE
Refresh assistant context when store data changes

### DIFF
--- a/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
@@ -24,6 +24,7 @@ class GROUI_Smart_Assistant_Admin {
         add_action( 'admin_init', array( $this, 'register_settings' ) );
         add_action( 'admin_notices', array( $this, 'maybe_show_missing_key_notice' ) );
         add_action( 'groui_smart_assistant_refresh_context', array( $this, 'refresh_context_cron' ) );
+        add_action( 'groui_smart_assistant_refresh_context_single', array( $this, 'refresh_context_cron' ) );
     }
 
     /**

--- a/groui-smart-assistant/includes/class-groui-smart-assistant.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant.php
@@ -77,6 +77,15 @@ class GROUI_Smart_Assistant {
         register_activation_hook( GROUI_SMART_ASSISTANT_PATH . 'groui-smart-assistant.php', array( $this, 'on_activate' ) );
         register_deactivation_hook( GROUI_SMART_ASSISTANT_PATH . 'groui-smart-assistant.php', array( $this, 'on_deactivate' ) );
         add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
+
+        add_action( 'save_post', array( $this, 'maybe_invalidate_context_on_post_change' ), 10, 3 );
+        add_action( 'deleted_post', array( $this, 'invalidate_context_cache' ) );
+        add_action( 'trashed_post', array( $this, 'invalidate_context_cache' ) );
+        add_action( 'untrashed_post', array( $this, 'invalidate_context_cache' ) );
+
+        add_action( 'created_term', array( $this, 'maybe_invalidate_context_on_term_change' ), 10, 3 );
+        add_action( 'edited_term', array( $this, 'maybe_invalidate_context_on_term_change' ), 10, 3 );
+        add_action( 'delete_term', array( $this, 'maybe_invalidate_context_on_term_change' ), 10, 5 );
     }
 
     /**
@@ -118,5 +127,100 @@ class GROUI_Smart_Assistant {
             wp_unschedule_event( $timestamp, 'groui_smart_assistant_refresh_context' );
         }
         delete_transient( self::CONTEXT_TRANSIENT );
+    }
+
+    /**
+     * Invalidate the cached context when relevant posts are created or updated.
+     *
+     * @param int      $post_id Post ID.
+     * @param object    $post    Post object (or data compatible with WP_Post).
+     * @param bool     $update  Whether this is an update.
+     *
+     * @return void
+     */
+    public function maybe_invalidate_context_on_post_change( $post_id, $post, $update ) {
+        unset( $update );
+
+        if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+            return;
+        }
+
+        if ( ! is_object( $post ) || empty( $post->post_type ) ) {
+            $post = get_post( $post_id );
+        }
+
+        if ( ! is_object( $post ) || empty( $post->post_type ) ) {
+            return;
+        }
+
+        $post_type = $post->post_type;
+
+        $relevant_post_types = apply_filters(
+            'groui_smart_assistant_relevant_post_types',
+            array( 'page', 'post', 'product' ),
+            $post
+        );
+
+        if ( in_array( $post_type, $relevant_post_types, true ) ) {
+            $this->invalidate_context_cache();
+        }
+    }
+
+    /**
+     * Invalidate the cached context when taxonomy terms change.
+     *
+     * @param int    $term_id Term ID.
+     * @param int    $tt_id   Term taxonomy ID.
+     * @param string $taxonomy Taxonomy slug.
+     * @param mixed  ...$args Additional arguments supplied by hooks such as delete_term.
+     *
+     * @return void
+     */
+    public function maybe_invalidate_context_on_term_change( $term_id, $tt_id = 0, $taxonomy = '', ...$args ) {
+        unset( $term_id, $tt_id, $args );
+
+        if ( function_exists( 'sanitize_key' ) ) {
+            $taxonomy = sanitize_key( $taxonomy );
+        } else {
+            $taxonomy = strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $taxonomy ) );
+        }
+
+        if ( empty( $taxonomy ) ) {
+            return;
+        }
+
+        $relevant_taxonomies = apply_filters(
+            'groui_smart_assistant_relevant_taxonomies',
+            array( 'product_cat', 'product_tag', 'product_brand', 'pwb-brand', 'brand', 'category' ),
+            $taxonomy
+        );
+
+        if ( in_array( $taxonomy, $relevant_taxonomies, true ) ) {
+            $this->invalidate_context_cache();
+        }
+    }
+
+    /**
+     * Remove the cached context and queue a quick refresh.
+     *
+     * @return void
+     */
+    public function invalidate_context_cache( ...$unused ) {
+        unset( $unused );
+        delete_transient( self::CONTEXT_TRANSIENT );
+        $this->schedule_context_refresh();
+    }
+
+    /**
+     * Schedule a near-immediate context refresh through WP-Cron.
+     *
+     * @return void
+     */
+    protected function schedule_context_refresh() {
+        if ( ! wp_next_scheduled( 'groui_smart_assistant_refresh_context_single' ) ) {
+            $delay = apply_filters( 'groui_smart_assistant_context_refresh_delay', 30 );
+            $delay = max( 5, absint( $delay ) );
+            wp_schedule_single_event( time() + $delay, 'groui_smart_assistant_refresh_context_single' );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- invalidate the cached assistant context whenever pages, posts, products or taxonomy terms are modified
- queue a single-run cron event to rebuild the context soon after content updates and hook the admin cron handler to it

## Testing
- php -l groui-smart-assistant/includes/class-groui-smart-assistant.php
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68df6e4610f48324bb6920f8e8689417