### PR TITLE
Add configurable OpenAI timeout option

### DIFF
--- a/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
@@ -130,6 +130,21 @@ class GROUI_Smart_Assistant_Admin {
             )
         );
 
+        // OpenAI timeout.
+        add_settings_field(
+            'openai_timeout',
+            __( 'Timeout de OpenAI (segundos)', 'groui-smart-assistant' ),
+            array( $this, 'render_number_field' ),
+            'groui-smart-assistant',
+            'groui_smart_assistant_general',
+            array(
+                'id'          => 'openai_timeout',
+                'min'         => 5,
+                'max'         => 60,
+                'description' => __( 'Tiempo máximo de espera para la respuesta de OpenAI. Contextos muy grandes pueden necesitar ampliar el timeout, pero 60 s es el límite recomendado.', 'groui-smart-assistant' ),
+            )
+        );
+
         // Debug toggle.
         add_settings_field(
             'enable_debug',
@@ -182,6 +197,15 @@ class GROUI_Smart_Assistant_Admin {
             $sanitized['max_products'] = 1000;
         }
 
+        $timeout = isset( $settings['openai_timeout'] ) ? absint( $settings['openai_timeout'] ) : 30;
+        if ( $timeout < 5 ) {
+            $timeout = 5;
+        }
+        if ( $timeout > 60 ) {
+            $timeout = 60;
+        }
+
+        $sanitized['openai_timeout'] = $timeout;
         $sanitized['enable_debug']   = ! empty( $settings['enable_debug'] );
 
         // Flush cached context whenever settings change.

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-context.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-context.php
@@ -371,6 +371,7 @@ class GROUI_Smart_Assistant_Context {
             // Use 0 to represent unlimited pages/products.
             'max_pages'      => 0,
             'max_products'   => 0,
+            'openai_timeout' => 30,
         );
 
         // Merge stored options with defaults, falling back when keys are missing.

--- a/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-openai.php
@@ -83,7 +83,15 @@ class GROUI_Smart_Assistant_OpenAI {
          */
         $body = apply_filters( 'groui_smart_assistant_openai_body', $body, $message, $context );
 
-        $timeout = apply_filters( 'groui_smart_assistant_openai_timeout', 30, $context, $message );
+        $timeout_setting = isset( $settings['openai_timeout'] ) ? absint( $settings['openai_timeout'] ) : 30;
+        if ( $timeout_setting < 5 ) {
+            $timeout_setting = 5;
+        }
+        if ( $timeout_setting > 60 ) {
+            $timeout_setting = 60;
+        }
+
+        $timeout = apply_filters( 'groui_smart_assistant_openai_timeout', $timeout_setting, $context, $message );
 
         $response = wp_remote_post(
             'https://api.openai.com/v1/chat/completions',


### PR DESCRIPTION
## Summary
- add an OpenAI timeout field in the admin settings with sanitization and guidance
- expose the timeout default through the context settings accessor
- use the configured timeout as the base value before applying the existing timeout filter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e096ee645c83248d97d4db2f52f5e6