### PR TITLE
Handle sitemap indexes and limit URL collection

### DIFF
--- a/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-admin.php
@@ -94,7 +94,7 @@ class GROUI_Smart_Assistant_Admin {
             'groui_smart_assistant_general',
             array(
                 'id'          => 'sitemap_url',
-                'description' => __( 'Se usará para extraer conocimiento de la web.', 'groui-smart-assistant' ),
+                'description' => __( 'Se usará para extraer conocimiento de la web. Soporta índices de sitemap y respeta límites configurables para evitar contextos enormes.', 'groui-smart-assistant' ),
             )
         );
 


### PR DESCRIPTION
## Summary
- detect sitemap indexes and traverse child sitemaps while enforcing configurable URL/file limits
- add filters to cap sitemap harvesting and log failures when debug mode is enabled
- clarify the sitemap URL setting description to mention index support and context limits

## Testing
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-context.php
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68e096f08174832495a44c157fd27e43