### PR TITLE
Add server-side budget filtering and numeric pricing metadata

### DIFF
--- a/groui-smart-assistant/includes/class-groui-smart-assistant-frontend.php
+++ b/groui-smart-assistant/includes/class-groui-smart-assistant-frontend.php
@@ -100,8 +100,14 @@ class GROUI_Smart_Assistant_Frontend {
         }
 
         $context = GROUI_Smart_Assistant_Context::instance()->refresh_context();
-        $openai  = new GROUI_Smart_Assistant_OpenAI();
-        $result  = $openai->query( $message, $context );
+        $budget  = $this->extract_budget_range( $message );
+
+        if ( ! empty( $budget ) ) {
+            $context = $this->apply_budget_filter_to_context( $context, $budget );
+        }
+
+        $openai = new GROUI_Smart_Assistant_OpenAI();
+        $result = $openai->query( $message, $context );
 
         // If the API returned a WP_Error, forward the message to the client.
         if ( is_wp_error( $result ) ) {
@@ -156,6 +162,7 @@ class GROUI_Smart_Assistant_Frontend {
             return array();
         }
 
+        $budget = $this->extract_budget_range( $query );
         $products = array();
         // Prioritize the products suggested by the model.
         if ( ! empty( $product_ids ) ) {
@@ -167,6 +174,11 @@ class GROUI_Smart_Assistant_Frontend {
                 if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
                     continue;
                 }
+                $price_amount = $this->get_product_price_amount( $product );
+                if ( ! $this->product_matches_budget( $price_amount, $budget ) ) {
+                    continue;
+                }
+
                 $products[ $product_id ] = $product;
             }
         }
@@ -208,6 +220,14 @@ class GROUI_Smart_Assistant_Frontend {
             if ( ! empty( $query ) ) {
                 $args['s'] = $query;
             }
+            if ( ! empty( $budget ) ) {
+                if ( isset( $budget['min'] ) && null !== $budget['min'] ) {
+                    $args['min_price'] = $budget['min'];
+                }
+                if ( isset( $budget['max'] ) && null !== $budget['max'] ) {
+                    $args['max_price'] = $budget['max'];
+                }
+            }
             if ( ! empty( $brand_term_ids ) && ! empty( $brand_taxonomies ) ) {
                 $tax_query = array( 'relation' => 'OR' );
 
@@ -232,6 +252,15 @@ class GROUI_Smart_Assistant_Frontend {
 
                 if ( ! empty( $query ) ) {
                     $fallback_args['s'] = $query;
+                }
+
+                if ( ! empty( $budget ) ) {
+                    if ( isset( $budget['min'] ) && null !== $budget['min'] ) {
+                        $fallback_args['min_price'] = $budget['min'];
+                    }
+                    if ( isset( $budget['max'] ) && null !== $budget['max'] ) {
+                        $fallback_args['max_price'] = $budget['max'];
+                    }
                 }
 
                 if ( ! empty( $brand_term_ids ) && ! empty( $brand_taxonomies ) ) {
@@ -265,10 +294,17 @@ class GROUI_Smart_Assistant_Frontend {
 
         $cards = array();
         foreach ( $products as $product ) {
+            $price_amount = $this->get_product_price_amount( $product );
+
+            if ( ! $this->product_matches_budget( $price_amount, $budget ) ) {
+                continue;
+            }
+
             $cards[] = array(
                 'id'         => $product->get_id(),
                 'name'       => $product->get_name(),
                 'price'      => wp_strip_all_tags( $product->get_price_html() ),
+                'price_amount' => $price_amount,
                 'permalink'  => $product->get_permalink(),
                 'image'      => wp_get_attachment_image_url( $product->get_image_id(), 'medium' ),
                 'short_desc' => wp_trim_words( wp_strip_all_tags( $product->get_short_description() ), 30 ),
@@ -277,5 +313,233 @@ class GROUI_Smart_Assistant_Frontend {
         }
 
         return $cards;
+    }
+
+    /**
+     * Return the numeric price of a WooCommerce product if available.
+     *
+     * @param WC_Product $product Product instance.
+     *
+     * @return float|null
+     */
+    protected function get_product_price_amount( WC_Product $product ) {
+        $price = $product->get_price();
+
+        if ( '' === $price || null === $price ) {
+            $price = $product->get_regular_price();
+        }
+
+        if ( '' === $price || null === $price ) {
+            return null;
+        }
+
+        if ( function_exists( 'wc_get_price_to_display' ) ) {
+            $display_price = wc_get_price_to_display( $product );
+        } else {
+            $display_price = $price;
+        }
+
+        if ( function_exists( 'wc_format_decimal' ) ) {
+            $decimals       = function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2;
+            $display_price  = wc_format_decimal( $display_price, $decimals );
+        }
+
+        return (float) $display_price;
+    }
+
+    /**
+     * Determine whether a price fits within the extracted budget range.
+     *
+     * @param float|null $price_amount Numeric product price.
+     * @param array      $budget       Budget range array with `min` and `max` keys.
+     *
+     * @return bool
+     */
+    protected function product_matches_budget( $price_amount, array $budget ) {
+        if ( empty( $budget ) ) {
+            return true;
+        }
+
+        if ( null === $price_amount ) {
+            // If we cannot determine the price, keep the product so the assistant can explain the limitation.
+            return true;
+        }
+
+        if ( isset( $budget['min'] ) && null !== $budget['min'] && $price_amount < $budget['min'] ) {
+            return false;
+        }
+
+        if ( isset( $budget['max'] ) && null !== $budget['max'] && $price_amount > $budget['max'] ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Parse a budget range (min/max) from a free-form text message.
+     *
+     * @param string $text Incoming message.
+     *
+     * @return array Empty array when no range is detected or an array with `min`/`max` keys.
+     */
+    protected function extract_budget_range( $text ) {
+        $text = is_string( $text ) ? trim( $text ) : '';
+
+        if ( '' === $text ) {
+            return array();
+        }
+
+        $has_currency_symbol = (bool) preg_match( '/[\$€£¥₽₹₱₡₫₦₩₮₴]/u', $text );
+        $normalized           = strtolower( $text );
+        $has_budget_keyword   = (bool) preg_match( '/\b(presupuesto|budget|precio|costo|cuesta|barato|caro|hasta|menos|menor|máximo|maximo|minimo|mínimo|desde|rango|gastar|gasto)\b/u', $normalized );
+
+        $pattern = '/(?:\$|€|£|¥|₽|₹|₱|mxn|usd|eur|cop|clp|ars|pen|s\/\.|soles|colones|gtq|crc|cad|aud|brl)?\s*(\d{1,3}(?:[\.\s]\d{3})*(?:[\.,]\d+)?|\d+(?:[\.,]\d+)?)/iu';
+        preg_match_all( $pattern, $text, $matches );
+
+        $numbers = array();
+
+        if ( ! empty( $matches[1] ) ) {
+            foreach ( $matches[1] as $candidate ) {
+                $value = $this->normalize_amount_from_text( $candidate );
+
+                if ( null !== $value ) {
+                    $numbers[] = $value;
+                }
+            }
+        }
+
+        if ( empty( $numbers ) || ( ! $has_currency_symbol && ! $has_budget_keyword ) ) {
+            return array();
+        }
+
+        $min = null;
+        $max = null;
+
+        if ( count( $numbers ) >= 2 ) {
+            sort( $numbers, SORT_NUMERIC );
+            $min = $numbers[0];
+            $max = $numbers[ count( $numbers ) - 1 ];
+        } else {
+            $value = $numbers[0];
+
+            if ( preg_match( '/(más de|mas de|mayor a|mayor que|desde|mínimo|minimo|al menos|arriba de)/u', $normalized ) ) {
+                $min = $value;
+            } elseif ( preg_match( '/(menos de|menor a|menor que|hasta|como máximo|maximo|máximo)/u', $normalized ) ) {
+                $max = $value;
+            } else {
+                $max = $value;
+            }
+        }
+
+        if ( null !== $min && null !== $max && $min > $max ) {
+            $tmp = $min;
+            $min = $max;
+            $max = $tmp;
+        }
+
+        if ( null === $min && null === $max ) {
+            return array();
+        }
+
+        return array(
+            'min' => null !== $min ? (float) $min : null,
+            'max' => null !== $max ? (float) $max : null,
+        );
+    }
+
+    /**
+     * Convert a textual number with localisation artefacts into a float.
+     *
+     * @param string $value Raw number string captured from the message.
+     *
+     * @return float|null
+     */
+    protected function normalize_amount_from_text( $value ) {
+        if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+            return null;
+        }
+
+        $value = trim( (string) $value );
+
+        if ( '' === $value ) {
+            return null;
+        }
+
+        $value = str_replace( array( ' ', "\xC2\xA0" ), '', $value );
+        $value = preg_replace( '/[^0-9,\.]/u', '', $value );
+
+        if ( '' === $value ) {
+            return null;
+        }
+
+        $last_comma = strrpos( $value, ',' );
+        $last_dot   = strrpos( $value, '.' );
+
+        if ( false !== $last_comma && false !== $last_dot ) {
+            if ( $last_comma > $last_dot ) {
+                $value = str_replace( '.', '', $value );
+                $value = str_replace( ',', '.', $value );
+            } else {
+                $value = str_replace( ',', '', $value );
+            }
+        } elseif ( false !== $last_comma ) {
+            $value = str_replace( ',', '.', $value );
+        } elseif ( false !== $last_dot ) {
+            $decimal_digits = strlen( substr( $value, $last_dot + 1 ) );
+            $dot_count      = substr_count( $value, '.' );
+
+            if ( $dot_count > 1 || $decimal_digits === 3 ) {
+                $value = str_replace( '.', '', $value );
+            }
+        }
+
+        if ( ! preg_match( '/^\d+(?:\.\d+)?$/', $value ) ) {
+            return null;
+        }
+
+        return (float) $value;
+    }
+
+    /**
+     * Apply budget-based filtering to the context before sending it to OpenAI.
+     *
+     * @param array $context Context array built from the site data.
+     * @param array $budget  Budget range with `min` and/or `max`.
+     *
+     * @return array Filtered context.
+     */
+    protected function apply_budget_filter_to_context( array $context, array $budget ) {
+        if ( empty( $context['products'] ) || ! is_array( $context['products'] ) ) {
+            return $context;
+        }
+
+        $filtered = array();
+
+        foreach ( $context['products'] as $product ) {
+            $price_amount = isset( $product['price_amount'] ) ? (float) $product['price_amount'] : null;
+
+            if ( $this->product_matches_budget( $price_amount, $budget ) ) {
+                $filtered[] = $product;
+            }
+        }
+
+        if ( ! isset( $context['_meta'] ) || ! is_array( $context['_meta'] ) ) {
+            $context['_meta'] = array();
+        }
+
+        $context['_meta']['budget_filter'] = array(
+            'min'     => isset( $budget['min'] ) ? $budget['min'] : null,
+            'max'     => isset( $budget['max'] ) ? $budget['max'] : null,
+            'matched' => count( $filtered ),
+        );
+
+        if ( ! empty( $filtered ) ) {
+            $context['products'] = array_values( $filtered );
+        } else {
+            $context['products'] = array();
+        }
+
+        return $context;
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable product summary helper that exposes both formatted and numeric prices
- parse potential budget ranges from chat messages and filter context/products before querying OpenAI
- respect min/max prices in WooCommerce fallbacks and return price-aware product cards with metadata

## Testing
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-context.php
- php -l groui-smart-assistant/includes/class-groui-smart-assistant-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68e0813fcfa88324bf1039ee37b4cf7d