### PR TITLE
Increase FAB style specificity and add launcher hint/markup

### DIFF
--- a/groui-smart-assistant/assets/css/groui-smart-assistant.css
+++ b/groui-smart-assistant/assets/css/groui-smart-assistant.css
@@ -43,42 +43,64 @@
 }
 
 /* Floating action button */
-.gsa-fab {
+.groui-smart-assistant-root .gsa-fab {
   position: fixed;
   right: 22px;
   bottom: 22px;
-  min-width: 120px;
-  height: 58px;
-  border-radius: 50%;
+  min-width: 176px;
+  height: 62px;
+  border-radius: 999px;
   backdrop-filter: blur(var(--gsa-blur));
   -webkit-backdrop-filter: blur(var(--gsa-blur));
-  background: linear-gradient(135deg, rgba(108, 92, 231, .92), rgba(88, 71, 223, .82));
-  border: 1px solid var(--gsa-border);
-  box-shadow: var(--gsa-shadow);
+  background: linear-gradient(135deg, #6d5ef8, #00d4ff);
+  border: 1px solid color-mix(in oklab, var(--gsa-border) 50%, white);
+  box-shadow: 0 16px 34px rgba(10, 12, 40, .32), 0 0 0 1px rgba(255, 255, 255, .08) inset;
   color: var(--gsa-text);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform .2s ease, box-shadow .2s ease, filter .3s ease;
+  transition: transform .2s ease, box-shadow .2s ease, filter .3s ease, background .3s ease;
   z-index: 9999;
   position: fixed;
-  padding: 0 16px;
-  gap: 10px;
+  padding: 0 18px 0 16px;
+  gap: 12px;
 }
-.gsa-fab:focus-visible {
+.groui-smart-assistant-root .gsa-fab:focus-visible {
   outline: 3px solid color-mix(in oklab, var(--gsa-accent) 60%, white);
   outline-offset: 3px;
 }
-.gsa-fab:focus-visible {
-  outline: 3px solid color-mix(in oklab, var(--gsa-accent) 60%, white);
-  outline-offset: 3px;
+.groui-smart-assistant-root .gsa-fab:hover {
+  transform: translateY(-3px) scale(1.02);
+  filter: brightness(1.05);
+  box-shadow: 0 18px 38px rgba(8, 10, 36, .38), 0 0 0 1px rgba(255, 255, 255, .12) inset;
 }
-.gsa-fab:hover { transform: translateY(-2px) scale(1.03); filter: brightness(1.04); }
-.gsa-fab:active { transform: scale(.98); }
-.gsa-fab__icon { position: relative; z-index: 2; display: flex; }
-.gsa-fab svg { width: 26px; height: 26px; }
-.gsa-fab__glow {
+.groui-smart-assistant-root .gsa-fab:active { transform: translateY(-1px) scale(.99); }
+.groui-smart-assistant-root .gsa-fab.is-open {
+  background: linear-gradient(135deg, #5c4ee7, #3fb1ff);
+}
+.groui-smart-assistant-root .gsa-fab__icon {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, .2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .3);
+}
+.groui-smart-assistant-root .gsa-fab svg { width: 20px; height: 20px; }
+.groui-smart-assistant-root .gsa-fab__pulse {
+  position: absolute;
+  inset: -8px;
+  border-radius: inherit;
+  background: radial-gradient(circle, rgba(108, 92, 231, .35), transparent 60%);
+  opacity: .8;
+  animation: gsa-pulse 12s ease-in-out infinite;
+  z-index: 0;
+}
+.groui-smart-assistant-root .gsa-fab__glow {
   position: absolute;
   inset: 0;
   border-radius: inherit;
@@ -88,18 +110,62 @@
   transition: opacity .3s ease;
   z-index: 1;
 }
-.gsa-fab:hover .gsa-fab__glow { opacity: 1; }
-.gsa-fab__label {
-  font: 700 12px/1 ui-sans-serif, system-ui;
+.groui-smart-assistant-root .gsa-fab:hover .gsa-fab__glow { opacity: 1; }
+.groui-smart-assistant-root .gsa-fab__text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  z-index: 2;
+}
+.groui-smart-assistant-root .gsa-fab__label {
+  font: 600 14px/1.1 ui-sans-serif, system-ui;
+  letter-spacing: .02em;
+}
+.groui-smart-assistant-root .gsa-fab__sublabel {
+  font: 500 11px/1 ui-sans-serif, system-ui;
+  color: rgba(255, 255, 255, .82);
+}
+.groui-smart-assistant-root .gsa-fab__tag {
+  position: absolute;
+  left: 42px;
+  top: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font: 700 10px/1 ui-sans-serif, system-ui;
   letter-spacing: .08em;
   text-transform: uppercase;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, .18);
-  border: 1px solid rgba(255, 255, 255, .3);
+  background: rgba(15, 16, 28, .7);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, .24);
+  z-index: 2;
+}
+.groui-smart-assistant-root .gsa-fab__tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: 0;
+  background: rgba(15, 16, 28, .88);
+  color: var(--gsa-text);
+  border: 1px solid rgba(255, 255, 255, .12);
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  max-width: 220px;
+  box-shadow: 0 10px 24px rgba(8, 10, 32, .28);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity .2s ease, transform .2s ease;
+  pointer-events: none;
+  z-index: 3;
+}
+.groui-smart-assistant-root .gsa-fab:hover .gsa-fab__tooltip,
+.groui-smart-assistant-root .gsa-fab:focus-visible .gsa-fab__tooltip,
+.groui-smart-assistant-root .gsa-fab__tooltip.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-.gsa-fab__badge {
+.groui-smart-assistant-root .gsa-fab__badge {
   position: absolute;
   top: -6px;
   right: 8px;
@@ -114,14 +180,27 @@
 }
 
 @media (max-width: 480px) {
-  .gsa-fab {
-    min-width: 100px;
-    height: 54px;
+  .groui-smart-assistant-root .gsa-fab {
+    min-width: 52px;
+    width: 52px;
+    height: 52px;
+    padding: 0;
     right: 14px;
     bottom: 14px;
   }
-  .gsa-fab svg { width: 22px; height: 22px; }
-  .gsa-fab__label { font-size: 11px; padding: 5px 8px; }
+  .groui-smart-assistant-root .gsa-fab__text { display: none; }
+  .groui-smart-assistant-root .gsa-fab__tag { display: none; }
+  .groui-smart-assistant-root .gsa-fab svg { width: 18px; height: 18px; }
+  .groui-smart-assistant-root .gsa-fab__icon { width: 34px; height: 34px; }
+}
+@media (hover: none) {
+  .groui-smart-assistant-root .gsa-fab:hover { transform: none; filter: none; }
+}
+@keyframes gsa-pulse {
+  0% { transform: scale(.96); opacity: .2; }
+  4% { transform: scale(1); opacity: .6; }
+  8% { transform: scale(.96); opacity: .2; }
+  100% { transform: scale(.96); opacity: .2; }
 }
 
 /* Chat window */


### PR DESCRIPTION
### Motivation
- Prevent site/theme CSS from overriding the assistant floating action button by scoping FAB rules to the plugin root. 
- Improve FAB visual/UX (pill layout, responsive sizing and glow/pulse) so it behaves consistently across desktop and mobile. 
- Provide a non-intrusive one-per-session hint/tooltip to surface the assistant to new users. 

### Description
- Prefix FAB selectors in `groui-smart-assistant/assets/css/groui-smart-assistant.css` with `.groui-smart-assistant-root` to increase specificity and adjust FAB styles (size, gradient, glow, pulse animation, z-index, responsive rules and keyframes). 
- Update the launcher markup in `groui-smart-assistant/assets/js/groui-smart-assistant.js` to include `gsa-fab__pulse`, `gsa-fab__text`, `gsa-fab__sublabel`, `gsa-fab__tag`, `gsa-fab__tooltip` and keep the existing badge and icon. 
- Implement tooltip / hint helpers `setLauncherHintVisible`, `showLauncherHint` and `hideLauncherHint` that use `sessionStorage` to show the hint once per session and a timeout to auto-hide it. 
- Wire the hint into lifecycle and events by calling `showLauncherHint()` on init, hiding the hint when the launcher is opened or clicked, and toggling `is-open` on the launcher in `togglePanel`. 

### Testing
- No automated test suites or commands were executed for these changes (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967316dd4a48324aea6b712c786de7b)